### PR TITLE
[REFACTOR] FavorColor UIColor extension으로 변경

### DIFF
--- a/Favor/Favor/Configuration/Extensions/UIColor+.swift
+++ b/Favor/Favor/Configuration/Extensions/UIColor+.swift
@@ -20,4 +20,26 @@ extension UIColor {
     let b = Double((rgb >>  0) & 0xFF) / 255
     self.init(red: r, green: g, blue: b, alpha: 1.0)
   }
+  
+  enum FavorColor: String {
+    case white = "#FFFFFF"
+    case black = "#000000"
+    case main = "#FF5862"
+    case background = "#F5F5F5"
+    case box1 = "#E0E0E0"
+    case box2 = "#BDBDBD"
+    case detail = "#9E9E9E"
+    case typo = "#424242"
+  }
+  
+  /// 색상을 적용하는 전역 메서드 입니다.
+  ///
+  /// ```
+  /// 사용하는 쪽
+  ///
+  /// label.textColor = .favorColor(.main)
+  static func favorColor(_ color: FavorColor) -> UIColor {
+    let favorColor = UIColor(color.rawValue)
+    return favorColor
+  }
 }


### PR DESCRIPTION
## ⚠️ 이슈 번호

> #24 

## ✌️ 구현/추가 사항

- `FavorColor`를 `FavorStyle`에서 `UIColor`의 `extension`으로 분리

## 💬 코멘트

> #23 반영
