### PR TITLE
[Feat] PropertyWrapper를 사용한 UserDefaults 구현

### DIFF
--- a/Favor/Favor.xcodeproj/project.pbxproj
+++ b/Favor/Favor.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2E11C2FF29A7AB29004B5C4A /* FavorEmptyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E11C2FE29A7AB29004B5C4A /* FavorEmptyCell.swift */; };
 		2E171164298035A400E34121 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E171163298035A400E34121 /* TabBarController.swift */; };
 		2E1C5661296C29210067FC78 /* OnboardingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1C5660296C29210067FC78 /* OnboardingVC.swift */; };
+		2E35647B29B8669D00FC9346 /* UserDefaultsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E35647A29B8669D00FC9346 /* UserDefaultsStorage.swift */; };
 		2E3668C6299FA6F4001FC283 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3668C5299FA6F4001FC283 /* UIView+.swift */; };
 		2E63538B295D900F00B23A14 /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 2E63538A295D900F00B23A14 /* RxMoya */; };
 		2E63538E295D904000B23A14 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 2E63538D295D904000B23A14 /* Kingfisher */; };
@@ -28,6 +29,7 @@
 		2E6C90C029A6783D00AF963A /* FavorTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6C90BF29A6783D00AF963A /* FavorTextField.swift */; };
 		2E6E86F829B3974C00C7AF69 /* Term-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2E6E86F729B3974C00C7AF69 /* Term-Info.plist */; };
 		2E76F58529601CD6002FF001 /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E76F58429601CD6002FF001 /* SplashVC.swift */; };
+		2E77370929B86D8E00DDF377 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E77370829B86D8E00DDF377 /* UserDefaultsKey.swift */; };
 		2E7C309C295D7C4300BAC43D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7C309B295D7C4300BAC43D /* AppDelegate.swift */; };
 		2E7C309E295D7C4300BAC43D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7C309D295D7C4300BAC43D /* SceneDelegate.swift */; };
 		2E7C30A5295D7C4500BAC43D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E7C30A4295D7C4500BAC43D /* Assets.xcassets */; };
@@ -174,6 +176,7 @@
 		2E11C2FE29A7AB29004B5C4A /* FavorEmptyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavorEmptyCell.swift; sourceTree = "<group>"; };
 		2E171163298035A400E34121 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		2E1C5660296C29210067FC78 /* OnboardingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingVC.swift; sourceTree = "<group>"; };
+		2E35647A29B8669D00FC9346 /* UserDefaultsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorage.swift; sourceTree = "<group>"; };
 		2E3668C5299FA6F4001FC283 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		2E6C90B029A607BD00AF963A /* FriendCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCell.swift; sourceTree = "<group>"; };
 		2E6C90B429A607FA00AF963A /* FriendCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCellReactor.swift; sourceTree = "<group>"; };
@@ -182,6 +185,7 @@
 		2E6C90BF29A6783D00AF963A /* FavorTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavorTextField.swift; sourceTree = "<group>"; };
 		2E6E86F729B3974C00C7AF69 /* Term-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Term-Info.plist"; sourceTree = "<group>"; };
 		2E76F58429601CD6002FF001 /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
+		2E77370829B86D8E00DDF377 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		2E7C3098295D7C4300BAC43D /* Favor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Favor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E7C309B295D7C4300BAC43D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2E7C309D295D7C4300BAC43D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -571,6 +575,7 @@
 				E562611F299DD37200D14020 /* SmallFavorButtonType.swift */,
 				E5626121299E3EDA00D14020 /* PlainFavorButtonType.swift */,
 				2E00561929A7E40F006CF302 /* ScrollDirection.swift */,
+				2E77370829B86D8E00DDF377 /* UserDefaultsKey.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -899,6 +904,7 @@
 		E55CF7B5298A6422002940D1 /* Storages */ = {
 			isa = PBXGroup;
 			children = (
+				2E35647A29B8669D00FC9346 /* UserDefaultsStorage.swift */,
 				E55CF7B6298A644C002940D1 /* FTUXStorage.swift */,
 			);
 			path = Storages;
@@ -1161,6 +1167,7 @@
 				2EE0D58129751EBD0064E932 /* SignUpVC.swift in Sources */,
 				2ED326BD29B2F78B001963D0 /* FindPasswordViewReactor.swift in Sources */,
 				2EE3691D29B634F300134760 /* UIButton+.swift in Sources */,
+				2E77370929B86D8E00DDF377 /* UserDefaultsKey.swift in Sources */,
 				2EE0D58D297832D20064E932 /* PHPickerManager.swift in Sources */,
 				E562610D29948D3600D14020 /* PickedPictureCellReactor.swift in Sources */,
 				2EA38494298D7C5F0081499C /* HeaderViewReactor.swift in Sources */,
@@ -1173,6 +1180,7 @@
 				2EC939EF299BB10D00C8C47F /* MyPageSectionHeaderViewReactor.swift in Sources */,
 				2E6C90B129A607BD00AF963A /* FriendCell.swift in Sources */,
 				2EC939DB29967F1900C8C47F /* MyPageViewReactor.swift in Sources */,
+				2E35647B29B8669D00FC9346 /* UserDefaultsStorage.swift in Sources */,
 				2EE07ED9296E8E3400048A3C /* ShareVC.swift in Sources */,
 				2EE3BA8D29AE15A8004FDCC9 /* APIManager.swift in Sources */,
 				2E1C5661296C29210067FC78 /* OnboardingVC.swift in Sources */,

--- a/Favor/Favor/Configuration/Constants/UserDefaultsKey.swift
+++ b/Favor/Favor/Configuration/Constants/UserDefaultsKey.swift
@@ -1,0 +1,15 @@
+//
+//  UserDefaultsKey.swift
+//  Favor
+//
+//  Created by 이창준 on 2023/03/08.
+//
+
+enum UserDefaultsKey: String {
+
+  // MARK: - FTUX
+
+  case isFirstLaunch
+  case isSignedIn
+
+}

--- a/Favor/Favor/Sources/Flows/AppFlow.swift
+++ b/Favor/Favor/Sources/Flows/AppFlow.swift
@@ -82,7 +82,9 @@ private extension AppFlow {
     
     return .one(flowContributor: .contribute(
       withNextPresentable: authFlow,
-      withNextStepper: OneStepper(withSingleStep: AppStep.authIsRequired(true))
+      withNextStepper: OneStepper(
+        withSingleStep: AppStep.authIsRequired
+      )
     ))
   }
   

--- a/Favor/Favor/Sources/Flows/AppStep.swift
+++ b/Favor/Favor/Sources/Flows/AppStep.swift
@@ -16,7 +16,7 @@ enum AppStep: Step {
   case rootIsRequired
 
   // MARK: - Auth
-  case authIsRequired(Bool)
+  case authIsRequired
   case authIsComplete
   case findPasswordIsRequired
   case validateEmailCodeIsRequired(String)

--- a/Favor/Favor/Sources/Flows/AppStep.swift
+++ b/Favor/Favor/Sources/Flows/AppStep.swift
@@ -12,8 +12,11 @@ import RxFlow
 enum AppStep: Step {
   case imagePickerIsRequired(PHPickerManager)
 
+  // MARK: - Root
+  case rootIsRequired
+
   // MARK: - Auth
-  case authIsRequired
+  case authIsRequired(Bool)
   case authIsComplete
   case findPasswordIsRequired
   case validateEmailCodeIsRequired(String)

--- a/Favor/Favor/Sources/Flows/AppStpper.swift
+++ b/Favor/Favor/Sources/Flows/AppStpper.swift
@@ -17,7 +17,6 @@ final class AppStepper: Stepper {
   private let disposeBag = DisposeBag()
   
   var initialStep: Step {
-    // TODO: State에 따라서 Step 변경
-    return AppStep.testIsRequired
+    return AppStep.rootIsRequired
   }
 }

--- a/Favor/Favor/Sources/Flows/AuthFlow.swift
+++ b/Favor/Favor/Sources/Flows/AuthFlow.swift
@@ -25,13 +25,17 @@ final class AuthFlow: Flow {
     
     switch step {
     case .authIsRequired:
-      return self.navigationToAuth()
-      
-    case .authIsComplete:
-      return .end(forwardToParentFlowWithStep: AppStep.authIsComplete)
+      return self.navigateToAuth()
+
+    case .onboardingIsRequired:
+      return self.navigateToOnboarding()
+
+    case .onboardingIsComplete:
+      self.rootViewController.presentedViewController?.dismiss(animated: true)
+      return .none
       
     case .signInIsRequired:
-      return self.navigationToSignIn()
+      return self.navigateToSignIn()
 
     case .findPasswordIsRequired:
       return self.navigateToFindPassword()
@@ -43,22 +47,19 @@ final class AuthFlow: Flow {
       return self.navigateToNewPassword()
       
     case .signUpIsRequired:
-      return self.navigationToSignUp()
+      return self.navigateToSignUp()
       
     case .setProfileIsRequired:
-      return self.navigationToSetProfile()
+      return self.navigateToSetProfile()
       
     case .termIsRequired(let userName):
-      return self.navigationToTerm(with: userName)
-      
-    case .onboardingIsRequired:
-      return .none
-      
-    case .onboardingIsComplete:
-      return .none
+      return self.navigateToTerm(with: userName)
 
     case .imagePickerIsRequired(let manager):
       return self.presentPHPicker(manager: manager)
+
+    case .authIsComplete:
+      return .end(forwardToParentFlowWithStep: AppStep.authIsComplete)
       
     default:
       return .none
@@ -67,7 +68,7 @@ final class AuthFlow: Flow {
 }
 
 private extension AuthFlow {
-  func navigationToAuth() -> FlowContributors {
+  func navigateToAuth() -> FlowContributors {
     let viewController = SelectSignInViewController()
     let reactor = SelectSignInViewReactor()
     viewController.reactor = reactor
@@ -79,7 +80,7 @@ private extension AuthFlow {
     ))
   }
   
-  func navigationToOnboarding() -> FlowContributors {
+  func navigateToOnboarding() -> FlowContributors {
     let onboardingFlow = OnboardingFlow()
 
     Flows.use(onboardingFlow, when: .created) { [unowned self] root in
@@ -95,7 +96,7 @@ private extension AuthFlow {
     ))
   }
   
-  func navigationToSignIn() -> FlowContributors {
+  func navigateToSignIn() -> FlowContributors {
     let viewController = SignInViewController()
     let reactor = SignInViewReactor()
     viewController.title = "로그인"
@@ -147,7 +148,7 @@ private extension AuthFlow {
     )
   }
   
-  func navigationToSignUp() -> FlowContributors {
+  func navigateToSignUp() -> FlowContributors {
     let viewController = SignUpViewController()
     let reactor = SignUpViewReactor()
     viewController.title = "회원가입"
@@ -160,7 +161,7 @@ private extension AuthFlow {
     )
   }
   
-  func navigationToSetProfile() -> FlowContributors {
+  func navigateToSetProfile() -> FlowContributors {
     let viewController = SetProfileViewController()
     let reactor = SetProfileViewReactor(pickerManager: PHPickerManager())
     viewController.title = "프로필 작성"
@@ -173,7 +174,7 @@ private extension AuthFlow {
     )
   }
   
-  func navigationToTerm(with userName: String) -> FlowContributors {
+  func navigateToTerm(with userName: String) -> FlowContributors {
     let viewController = TermViewController()
     let reactor = TermViewReactor(with: userName)
     viewController.reactor = reactor

--- a/Favor/Favor/Sources/Flows/OnboardingFlow.swift
+++ b/Favor/Favor/Sources/Flows/OnboardingFlow.swift
@@ -23,7 +23,9 @@ final class OnboardingFlow: Flow {
     switch step {
     case .onboardingIsRequired:
       return .one(flowContributor: .contribute(withNext: self.rootViewController))
+
     case .onboardingIsComplete:
+      FTUXStorage.isFirstLaunch = false
       return .end(forwardToParentFlowWithStep: AppStep.onboardingIsComplete)
       
     default:

--- a/Favor/Favor/Sources/Scenes/Application/SceneDelegate.swift
+++ b/Favor/Favor/Sources/Scenes/Application/SceneDelegate.swift
@@ -21,14 +21,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     let window = UIWindow(windowScene: windowScene)
     self.window = window
-    
-    let appFlow = AppFlow()
+
+    self.enableNavigateLog()
+    let appFlow = AppFlow(window: window)
     self.coordinator.coordinate(flow: appFlow, with: AppStepper())
-    
-    Flows.use(appFlow, when: .created) { root in
-      window.rootViewController = root
-      window.makeKeyAndVisible()
-    }
+    window.makeKeyAndVisible()
 	}
 }
 

--- a/Favor/Favor/Sources/Scenes/Auth/Reactors/SelectSignInViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/Reactors/SelectSignInViewReactor.swift
@@ -19,6 +19,7 @@ final class SelectSignInViewReactor: Reactor, Stepper {
   var steps = PublishRelay<Step>()
   
   enum Action {
+    case loadView
     case emailLoginButtonTap
     case signUpButtonTap
   }
@@ -39,6 +40,12 @@ final class SelectSignInViewReactor: Reactor, Stepper {
   
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
+    case .loadView:
+      if FTUXStorage.isFirstLaunch {
+        self.steps.accept(AppStep.onboardingIsRequired)
+      }
+      return .empty()
+
     case .emailLoginButtonTap:
       self.steps.accept(AppStep.signInIsRequired)
       return .empty()

--- a/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SelectSignInVC.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SelectSignInVC.swift
@@ -48,11 +48,16 @@ final class SelectSignInViewController: BaseViewController, View {
 
   // MARK: - Life Cycle
   
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    self.reactor?.action.onNext(.loadView)
+  }
+  
   // MARK: - Binding
   
   func bind(reactor: SelectSignInViewReactor) {
     // Action
-    
     self.emailLoginButton.rx.tap
       .map { Reactor.Action.emailLoginButtonTap }
       .bind(to: reactor.action)

--- a/Favor/Favor/Sources/Scenes/Onboarding/OnboardingVC.swift
+++ b/Favor/Favor/Sources/Scenes/Onboarding/OnboardingVC.swift
@@ -48,7 +48,8 @@ final class OnboardingViewController: BaseViewController, Stepper {
         $0.configuration = LargeFavorButtonType.main("시작하기").configuration
       }
     }
-    
+    btn.addTarget(self, action: #selector(dismissOnboarding), for: .touchUpInside)
+
     return btn
   }()
   
@@ -77,7 +78,7 @@ final class OnboardingViewController: BaseViewController, Stepper {
   private var currentPage: Int = 0 {
     didSet {
       self.pageControl.currentPage = currentPage
-      self.startButton.isEnabled = self.currentPage == 2 ? true : false
+      self.startButton.isEnabled = self.currentPage == self.slides.count - 1 ? true : false
     }
   }
   
@@ -112,6 +113,13 @@ final class OnboardingViewController: BaseViewController, Stepper {
       make.leading.trailing.equalTo(self.view.layoutMarginsGuide)
       make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(32)
     }
+  }
+
+  // MARK: - Functions
+
+  @objc
+  func dismissOnboarding() {
+    self.steps.accept(AppStep.onboardingIsComplete)
   }
 }
 

--- a/Favor/Favor/Sources/Storages/FTUXStorage.swift
+++ b/Favor/Favor/Sources/Storages/FTUXStorage.swift
@@ -8,15 +8,12 @@
 import Foundation
 
 final class FTUXStorage {
-  
-  private let key = "LAUNCHED_BEFORE"
-  private let userDefaults = UserDefaults.standard
-  
-  var isFirstLaunched: Bool {
-    return userDefaults.bool(forKey: key)
-  }
+  @UserDefault(key: .isFirstLaunch, defaultValue: true)
+  static var isFirstLaunch: Bool
+  @UserDefault(key: .isSignedIn, defaultValue: false)
+  static var isSignedIn: Bool
   
   func setFirstLaunch() {
-    userDefaults.set(true, forKey: key)
+    FTUXStorage.isFirstLaunch = false
   }
 }

--- a/Favor/Favor/Sources/Storages/FTUXStorage.swift
+++ b/Favor/Favor/Sources/Storages/FTUXStorage.swift
@@ -10,10 +10,7 @@ import Foundation
 final class FTUXStorage {
   @UserDefault(key: .isFirstLaunch, defaultValue: true)
   static var isFirstLaunch: Bool
+  
   @UserDefault(key: .isSignedIn, defaultValue: false)
   static var isSignedIn: Bool
-  
-  func setFirstLaunch() {
-    FTUXStorage.isFirstLaunch = false
-  }
 }

--- a/Favor/Favor/Sources/Storages/UserDefaultsStorage.swift
+++ b/Favor/Favor/Sources/Storages/UserDefaultsStorage.swift
@@ -1,0 +1,28 @@
+//
+//  UserDefaultsStorage.swift
+//  Favor
+//
+//  Created by 이창준 on 2023/03/08.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<T> {
+  private let key: UserDefaultsKey
+  private let defaultValue: T
+
+  init(key: UserDefaultsKey, defaultValue: T) {
+    self.key = key
+    self.defaultValue = defaultValue
+  }
+
+  var wrappedValue: T {
+    get {
+      return UserDefaults.standard.object(forKey: key.rawValue) as? T ?? defaultValue
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: key.rawValue)
+    }
+  }
+}


### PR DESCRIPTION
## ⚠️ 이슈 번호

> #79 

## ✌️ 구현/추가 사항

- `PropertyWrapper`를 사용한 `UserDefaults` 구현
- `isSignedIn`과 `isFirstLaunch` 값에 따라 앱 초기 화면 구분

## 💬 코멘트

> 추가한 기능에 대한 설명 및 리뷰 참고 사항

`UserDefaults` 경우는 우선 `Storages` 디렉토리에 넣어뒀어!
어디에 넣어둘지는 회의 때 같이 이야기해보면 좋을 것 같아

``` Swift
// UserDefaultsStorage.swift
import Foundation

@propertyWrapper
struct UserDefault<T> {
  private let key: UserDefaultsKey
  private let defaultValue: T

  init(key: UserDefaultsKey, defaultValue: T) {
    self.key = key
    self.defaultValue = defaultValue
  }

  var wrappedValue: T {
    get {
      return UserDefaults.standard.object(forKey: key.rawValue) as? T ?? defaultValue
    }
    set {
      UserDefaults.standard.set(newValue, forKey: key.rawValue)
    }
  }
}
```

`key`에 들어가는 `UserDefaultsKey`는 `Constants` 디렉토리에 넣어뒀어!

``` Swift

enum UserDefaultsKey: String {

  // MARK: - FTUX

  case isFirstLaunch
  case isSignedIn

}
```

> 결과
 
https://user-images.githubusercontent.com/60438045/223703953-9deeec04-301e-4294-a2d0-2f895aef9796.mov

