### PR TITLE
[Feat] 네트워크 에러 처리 

### DIFF
--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIError.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIError.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  APIError.swift
 //  
 //
 //  Created by 김응철 on 2023/03/14.

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIError.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIError.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김응철 on 2023/03/14.
+//
+
+import Foundation
+
+public enum APIError: Error {
+  case internetConnection(Error)
+  case timeOut(Error)
+  case restError(Error, statusCode: Int? = nil, errorCode: String? = nil)
+}

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/DataMapping/ResponseDTO.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/DataMapping/ResponseDTO.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ResponseDTO.swift
 //  
 //
 //  Created by 김응철 on 2023/03/14.

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/DataMapping/ResponseDTO.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/DataMapping/ResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김응철 on 2023/03/14.
+//
+
+import Foundation
+
+struct ResponseDTO<T: Decodable> {
+  let responseCode: String
+  let responseMessage: String
+  let data: T
+}

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+NetworkError.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+NetworkError.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by 김응철 on 2023/03/14.
+//
+
+import Foundation
+
+import Alamofire
+import Moya
+
+extension Networking {
+  static func convertToURLError(_ error: Error) -> URLError? {
+    switch error {
+    case let MoyaError.underlying(afError as AFError, _):
+      fallthrough
+    case let afError as AFError:
+      return afError.underlyingError as? URLError
+    case let urlError as URLError:
+      return urlError
+    default:
+      return nil
+    }
+  }
+  
+  static func isNotConnection(_ error: Error) -> Bool {
+    Self.convertToURLError(error)?.code == .notConnectedToInternet
+  }
+  
+  static func isLostConnection(_ error: Error) -> Bool {
+    switch error {
+    case let AFError.sessionTaskFailed(error: posixError as POSIXError)
+      where posixError.code == .ECONNABORTED:
+      break
+    case let MoyaError.underlying(urlError as URLError, _):
+      guard urlError.code == .networkConnectionLost else { fallthrough }
+      break
+    default:
+      return false
+    }
+    return true
+  }
+}

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+NetworkError.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+NetworkError.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Networking+NetworkError.swift
 //  
 //
 //  Created by 김응철 on 2023/03/14.

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+Request.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+Request.swift
@@ -1,0 +1,40 @@
+//
+//  Networking+Request.swift
+//  
+//
+//  Created by 김응철 on 2023/03/14.
+//
+
+import RxSwift
+import Moya
+
+extension Networking {
+  public func handleInternetConnection<T: Any>(_ error: Error) throws -> Single<T> {
+    guard
+      let urlError = Self.convertToURLError(error),
+      Self.isNotConnection(error)
+    else { throw error }
+    throw APIError.internetConnection(urlError)
+  }
+  
+  public func handleTimeOut<T: Any>(_ error: Error) throws -> Single<T> {
+    guard
+      let urlError = Self.convertToURLError(error),
+      urlError.code == .timedOut
+    else { throw error }
+    throw APIError.timeOut(urlError)
+  }
+
+  public func handleREST<T: Any>(_ error: Error) throws -> Single<T> {
+    guard error is APIError else {
+      throw APIError.restError(
+        error,
+        statusCode: (error as? MoyaError)?.response?.statusCode,
+        errorCode: (try? (error as? MoyaError)?
+          .response?
+          .mapJSON() as? [String: Any])?["responseCode"] as? String
+      )
+    }
+    throw error
+  }
+}

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
@@ -25,8 +25,7 @@ public final class Networking<TargetType: BaseTargetType> {
   // MARK: - Initializer
 
   public init() {
-    let provider = MoyaProvider<TargetType>()
-    self.provider = provider
+    self.provider = MoyaProvider<TargetType>()
   }
   
   // MARK: - Functions

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
@@ -26,24 +26,40 @@ public final class Networking<TargetType: BaseTargetType> {
 
   public init() {
     let provider = MoyaProvider<TargetType>()
-    provider.session.sessionConfiguration.timeoutIntervalForRequest = 10
     self.provider = provider
   }
-
+  
   // MARK: - Functions
-
+  
   public func request(
     _ target: TargetType
   ) -> Single<Response> {
     let requestURL = "\(target.method.rawValue) \(target.path)"
     return self.provider.rx.request(target)
       .filterSuccessfulStatusCodes()
+      .catch(self.handleInternetConnection)
+      .catch(self.handleTimeOut)
+      .catch(self.handleREST)
       .do(
         onSuccess: { value in
           let message = "🌐 ⭕ SUCCESS: \(requestURL) [\(value.statusCode)]"
           os_log(.debug, "\(message)")
         },
         onError: { error in
+          switch error {
+          case APIError.internetConnection:
+            // 인터넷이 끊겼을 때,
+            break
+          case APIError.timeOut:
+            // 요청 시간이 초과됐을 때,
+            break
+          case let APIError.restError(_, statusCode, errorCode):
+            // statusCode가 200..<300 이외의 Response
+            break
+          default:
+            // 다른 에러
+            break
+          }
           if let response = (error as? MoyaError)?.response {
             let message = "🌐 ❌ FAILURE: \(requestURL) [\(response.statusCode)]"
             os_log(.error, "\(message)")


### PR DESCRIPTION
## ⚠️ 이슈 번호

> 브랜치에 할당된 이슈 번호
#86 

## ✌️ 구현/추가 사항

- `Networking+Request` 구현 
- `Networking+NetworkError`구현
- `APIError` `enum`으로 분기처리
- 전역적으로 사용하는 `ResponseDTO`를 구현 

## 💬 코멘트

- https://ios-development.tistory.com/797 와 동일하게 구현함
- `APIError`의 `restError`를 이용하여 `toast` 알럿 띄우기 예정

> 추가한 기능에 대한 설명 및 리뷰 참고 사항

- 서버에서 제공하는 `responseCode`를 `rawValue`가 `String`으로 `enum`으로 구현 예정
