### PR TITLE
[Feat] 토스트 메시지

### DIFF
--- a/Favor/Favor/Sources/Scenes/Home/ViewControllers/HomeVC.swift
+++ b/Favor/Favor/Sources/Scenes/Home/ViewControllers/HomeVC.swift
@@ -87,6 +87,18 @@ final class HomeViewController: BaseViewController, View {
     super.viewDidLoad()
 
     self.setupCollectionView()
+
+//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
+//      self.makeToast("테스트 토스트 메시지", duration: .forever)
+//    }
+//
+//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
+//      self.hideToast()
+//    }
+//
+//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(6)) {
+//      self.makeToast(".short는 3초입니다! 👏", duration: .short)
+//    }
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -124,6 +136,9 @@ final class HomeViewController: BaseViewController, View {
   func bind(reactor: HomeViewReactor) {
     // Action
     self.searchButton.rx.tap
+      .do(onNext: {
+        self.presentToast("🍞 토스트 메시지 🍞", duration: .short)
+      })
       .map { Reactor.Action.searchButtonDidTap }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)

--- a/Favor/Favor/Sources/Scenes/Home/ViewControllers/HomeVC.swift
+++ b/Favor/Favor/Sources/Scenes/Home/ViewControllers/HomeVC.swift
@@ -87,18 +87,6 @@ final class HomeViewController: BaseViewController, View {
     super.viewDidLoad()
 
     self.setupCollectionView()
-
-//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
-//      self.makeToast("테스트 토스트 메시지", duration: .forever)
-//    }
-//
-//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
-//      self.hideToast()
-//    }
-//
-//    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(6)) {
-//      self.makeToast(".short는 3초입니다! 👏", duration: .short)
-//    }
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -136,7 +124,7 @@ final class HomeViewController: BaseViewController, View {
   func bind(reactor: HomeViewReactor) {
     // Action
     self.searchButton.rx.tap
-      .do(onNext: {
+      .do(onNext: { // TODO: 토스트 메시지 테스트용 코드 삭제
         self.presentToast("🍞 토스트 메시지 🍞", duration: .short)
       })
       .map { Reactor.Action.searchButtonDidTap }

--- a/Favor/FavorKit/Sources/FavorKit/Base/BaseViewController.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Base/BaseViewController.swift
@@ -14,12 +14,13 @@ open class BaseViewController: UIViewController {
   /// A dispose bag. 각 ViewController에 종속적이다.
   public final var disposeBag = DisposeBag()
 
+  private var toast: FavorToastMessageView?
+
   open override func viewDidLoad() {
     super.viewDidLoad()
     setupLayouts()
     setupConstraints()
     setupStyles()
-    bind()
   }
 
   /// UI 프로퍼티를 view에 할당합니다.
@@ -62,6 +63,19 @@ open class BaseViewController: UIViewController {
       top: 0, leading: 20.0, bottom: 0, trailing: 20.0
     )
   }
-  
-  open func bind() { }
+}
+
+// MARK: - Toast
+
+public extension BaseViewController {
+  func presentToast(_ message: String, duration: ToastManager.duration) {
+    self.toast = ToastManager.shared.prepareToast(message)
+    guard let toast = self.toast else { return }
+    ToastManager.shared.showToast(toast, at: self)
+  }
+
+  func dismissToast() {
+    guard let toast = self.toast else { return }
+    ToastManager.shared.hideToast(toast, from: self)
+  }
 }

--- a/Favor/FavorKit/Sources/FavorKit/Base/BaseViewController.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Base/BaseViewController.swift
@@ -23,6 +23,11 @@ open class BaseViewController: UIViewController {
     setupStyles()
   }
 
+  open override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    ToastManager.shared.resetToast()
+  }
+
   /// UI 프로퍼티를 view에 할당합니다.
   ///
   /// ```
@@ -71,7 +76,7 @@ public extension BaseViewController {
   func presentToast(_ message: String, duration: ToastManager.duration) {
     self.toast = ToastManager.shared.prepareToast(message)
     guard let toast = self.toast else { return }
-    ToastManager.shared.showToast(toast, at: self)
+    ToastManager.shared.showNewToast(toast, at: self)
   }
 
   func dismissToast() {

--- a/Favor/FavorKit/Sources/FavorKit/Components/FavorToastMessageView.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Components/FavorToastMessageView.swift
@@ -1,0 +1,104 @@
+//
+//  FavorToastMessageView.swift
+//  Favor
+//
+//  Created by 이창준 on 2023/03/14.
+//
+
+import UIKit
+
+import SnapKit
+
+public final class FavorToastMessageView: UIView {
+
+  // MARK: - Constants
+
+  // MARK: - Properties
+
+  public var width: CGFloat = 375 {
+    didSet { self.updateWidth() }
+  }
+
+  public var message: String? {
+    didSet { self.updateMessage() }
+  }
+
+  // MARK: - UI Components
+
+  private lazy var titleLabel: UILabel = {
+    let label = UILabel()
+    label.font = .favorFont(.regular, size: 14)
+    label.textColor = .favorColor(.white)
+    label.textAlignment = .center
+    label.numberOfLines = 1
+    label.lineBreakMode = .byTruncatingTail
+    return label
+  }()
+
+  // MARK: - Initializer
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.setupStyles()
+    self.setupLayouts()
+    self.setupConstraints()
+  }
+
+  public convenience init(_ message: String) {
+    self.init(frame: .zero)
+
+    self.message = message
+    self.updateMessage()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Functions
+
+}
+
+// MARK: - UI Setup
+
+extension FavorToastMessageView: BaseView {
+  public func setupStyles() {
+    self.autoresizingMask = [
+      .flexibleLeftMargin,
+      .flexibleRightMargin,
+      .flexibleTopMargin,
+      .flexibleBottomMargin
+    ]
+    self.layer.cornerRadius = 20
+    self.backgroundColor = .favorColor(.titleAndLine)
+  }
+
+  public func setupLayouts() {
+    self.addSubview(self.titleLabel)
+  }
+
+  public func setupConstraints() {
+    self.snp.makeConstraints { make in
+      make.height.equalTo(40)
+    }
+
+    self.titleLabel.snp.makeConstraints { make in
+      make.center.equalToSuperview()
+    }
+  }
+}
+
+// MARK: - Privates
+
+private extension FavorToastMessageView {
+  func updateWidth() {
+    self.snp.updateConstraints { make in
+      make.width.equalTo(self.width)
+    }
+  }
+
+  func updateMessage() {
+    self.titleLabel.text = self.message
+  }
+}

--- a/Favor/FavorKit/Sources/FavorKit/Components/FavorToastMessageView.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Components/FavorToastMessageView.swift
@@ -23,6 +23,8 @@ public final class FavorToastMessageView: UIView {
     didSet { self.updateMessage() }
   }
 
+  public var duration: ToastManager.duration?
+
   // MARK: - UI Components
 
   private lazy var titleLabel: UILabel = {

--- a/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
+++ b/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
@@ -1,0 +1,33 @@
+//
+//  Queue.swift
+//  Favor
+//
+//  Created by 이창준 on 2023/03/14.
+//
+
+struct Queue<T> {
+  private var queue: [T?] = []
+  private var front: Int = 0
+
+  public var frontIndex: Int { return self.front }
+
+  public var size: Int { return self.queue.count }
+
+  public var isEmpty: Bool { return self.queue[self.front] == nil }
+
+  public mutating func enqueue(_ element: T) {
+    self.queue.append(element)
+  }
+
+  @discardableResult
+  public mutating func dequeue() -> T? {
+    guard
+      self.front <= self.size,
+      let element = self.queue[self.front]
+    else { return nil }
+    
+    self.queue[self.front] = nil
+    self.front += 1
+    return element
+  }
+}

--- a/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
+++ b/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
@@ -23,11 +23,21 @@ struct Queue<T> {
   public mutating func dequeue() -> T? {
     guard
       self.front <= self.size,
+      !self.isEmpty,
       let element = self.queue[self.front]
     else { return nil }
     
     self.queue[self.front] = nil
     self.front += 1
+    return element
+  }
+
+  public func peek() -> T? {
+    guard
+      self.front < self.size,
+      let element = self.queue[self.front]
+    else { return nil }
+
     return element
   }
 }

--- a/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
+++ b/Favor/FavorKit/Sources/FavorKit/DataStructure/Queue.swift
@@ -13,7 +13,7 @@ struct Queue<T> {
 
   public var size: Int { return self.queue.count }
 
-  public var isEmpty: Bool { return self.queue[self.front] == nil }
+  public var isEmpty: Bool { return self.size == 0 || self.queue[self.front] == nil }
 
   public mutating func enqueue(_ element: T) {
     self.queue.append(element)

--- a/Favor/FavorKit/Sources/FavorKit/Managers/ToastManager.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Managers/ToastManager.swift
@@ -1,0 +1,106 @@
+//
+//  ToastManager.swift
+//  Favor
+//
+//  Created by 이창준 on 2023/03/14.
+//
+
+import UIKit
+
+import SnapKit
+
+public final class ToastManager {
+
+  // MARK: - Constants
+
+  public enum duration {
+    case short, long, forever
+
+    var timeInterval: TimeInterval {
+      switch self {
+      case .short: return 3.0
+      case .long: return 5.0
+      case .forever: return 180.0
+      }
+    }
+  }
+
+  // MARK: - Properties
+
+  public static let shared = ToastManager()
+
+  public var popInDuration: TimeInterval = 0.2
+  public var popOutDuration: TimeInterval = 0.3
+
+  private var queue = Queue<FavorToastMessageView>()
+
+  // MARK: - Initializer
+
+  private init() { }
+
+  // MARK: - Functions
+
+  /// `FavorToastMessageView` 객체를 생성합니다.
+  public func prepareToast(_ message: String) -> FavorToastMessageView {
+    let toast = FavorToastMessageView(message)
+    return toast
+  }
+
+  /// ToastView를 최상단 VC 위에 띄웁니다.
+  public func showToast(
+    _ toast: FavorToastMessageView,
+    at viewController: BaseViewController,
+    duration: ToastManager.duration = .short,
+    completion: (() -> Void)? = nil
+  ) {
+    toast.alpha = 0.0
+
+    self.queue.enqueue(toast)
+    viewController.view.addSubview(toast)
+
+    toast.snp.makeConstraints { make in
+      make.centerX.equalToSuperview()
+      make.bottom.equalTo(viewController.view.safeAreaLayoutGuide)
+      make.directionalHorizontalEdges.equalTo(viewController.view.layoutMarginsGuide).inset(20)
+    }
+    viewController.view.layoutIfNeeded()
+
+    let animator = UIViewPropertyAnimator(duration: self.popInDuration, curve: .easeInOut) {
+      toast.alpha = 1.0
+      toast.snp.updateConstraints { make in
+        make.bottom.equalTo(viewController.view.safeAreaLayoutGuide).inset(20)
+      }
+      viewController.view.layoutIfNeeded()
+    }
+    animator.addCompletion { _ in
+      self.hideToast(toast, from: viewController, duration: duration.timeInterval)
+      if let completion { completion() }
+    }
+    animator.startAnimation()
+  }
+
+  public func hideToast(
+    _ toast: FavorToastMessageView,
+    from viewController: BaseViewController,
+    duration: TimeInterval? = nil
+  ) {
+    let animator = UIViewPropertyAnimator(duration: self.popOutDuration, curve: .easeInOut) {
+      toast.alpha = 0.0
+      toast.snp.updateConstraints { make in
+        make.bottom.equalTo(viewController.view.safeAreaLayoutGuide)
+      }
+      viewController.view.layoutIfNeeded()
+    }
+    animator.addCompletion { _ in
+      DispatchQueue.main.asyncAfter(deadline: .now() + self.popOutDuration) {
+        toast.removeFromSuperview()
+        self.queue.dequeue()
+      }
+    }
+    if let duration {
+      animator.startAnimation(afterDelay: duration)
+    } else {
+      animator.startAnimation()
+    }
+  }
+}


### PR DESCRIPTION
## ⚠️ 이슈 번호

> #87 

## ✌️ 구현/추가 사항

- 토스트 메시지 구현
- `Queue` 데이터 구조 추가

## 💬 코멘트

> 추가한 기능에 대한 설명 및 리뷰 참고 사항

https://user-images.githubusercontent.com/60438045/224982539-37e7b598-e5f8-457b-a301-397a95125e70.mov

- 여러개의 메시지가 들어오는 경우 이전 메시지가 사라지면 뜨도록 구현
- 해당 뷰컨에서 벗어나면 (`viewDidDisappear`) 큐잉된 모든 메시지가 리셋되도록 구현

- 사용법 매우 간단! ⬇️
``` Swift
// Any BaseViewController
final class TestViewController: BaseViewController {
  func foo() {
    self.presentToast("테스트 토스트 메시지", duration: .short)
    self.presentToast("사라지지 않는 메시지", duration: .forever)
    self.dismissToast()
  }
}
```

`HomeFlow` 브랜치에서 따온 브랜치라
해당 브랜치에서 작업하던 내용들도 포함되어 있어서 일단 `HomeFlow` 브랜치에 머지할게..!
