### PR TITLE
[Feat] 회원가입 네트워크 로직 구현

### DIFF
--- a/Favor/Favor.xcodeproj/project.pbxproj
+++ b/Favor/Favor.xcodeproj/project.pbxproj
@@ -272,9 +272,9 @@
 			isa = PBXGroup;
 			children = (
 				2ED326AC29B0DB9D001963D0 /* TermSection.swift */,
+				2EE07EE2296EDC9E00048A3C /* ViewControllers */,
 				2EE07EE4296EDCA900048A3C /* Reactors */,
 				2ED8CB4529B0C2E400E7B547 /* Views */,
-				2EE07EE2296EDC9E00048A3C /* ViewControllers */,
 			);
 			path = Auth;
 			sourceTree = "<group>";

--- a/Favor/Favor/Sources/Scenes/Auth/Reactors/SetProfileViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/Reactors/SetProfileViewReactor.swift
@@ -9,6 +9,7 @@ import OSLog
 import UIKit
 
 import FavorKit
+import FavorNetworkKit
 import ReactorKit
 import RxCocoa
 import RxFlow
@@ -20,6 +21,7 @@ final class SetProfileViewReactor: Reactor, Stepper {
   var initialState: State
   let pickerManager: PHPickerManager
   var steps = PublishRelay<Step>()
+  let networking = UserNetworking()
 
   // Global States
   let isNameEmpty = BehaviorRelay<Bool>(value: true)
@@ -35,17 +37,21 @@ final class SetProfileViewReactor: Reactor, Stepper {
   enum Mutation {
     case updateProfileImage(UIImage?)
     case updateUserName(String)
+    case updateUserId(String)
     case updateNameValidationResult(Bool)
     case updateIDValidationResult(ValidationResult)
     case validateNextButton(Bool)
+    case updateLoading(Bool)
   }
   
   struct State {
     var profileImage: UIImage?
     var userName: String = ""
+    var userId: String = ""
     var nameValidationResult: Bool = true
     var idValidationResult: ValidationResult = .empty
     var isNextButtonEnabled: Bool = false
+    var isLoading: Bool = false
   }
   
   // MARK: - Initializer
@@ -76,11 +82,28 @@ final class SetProfileViewReactor: Reactor, Stepper {
       os_log(.debug, "ID TextField did update: \(id).")
       let idValidationResult = AuthValidationManager(type: .id).validate(id)
       self.idValidate.accept(idValidationResult)
-      return .just(.updateIDValidationResult(idValidationResult))
+      return .concat([
+        .just(.updateUserId(id)),
+        .just(.updateIDValidationResult(idValidationResult))
+      ])
       
     case .nextFlowRequested:
       os_log(.debug, "Next button or return key from keyboard did tap.")
       if self.currentState.isNextButtonEnabled {
+        let userId = self.currentState.userId
+        let userName = self.currentState.userName
+        
+        return .concat([
+          .just(.updateLoading(true)),
+
+          // TODO: Profile Networking
+//          networking.request(.patchProfile(
+//            userId: <#T##String#>,
+//            name: <#T##String#>,
+//            userNo: <#T##Int#>
+//          ))
+          
+        ])
         self.steps.accept(AppStep.termIsRequired(self.currentState.userName))
       }
       return .empty()
@@ -120,9 +143,15 @@ final class SetProfileViewReactor: Reactor, Stepper {
 
     case .updateIDValidationResult(let isIDValid):
       newState.idValidationResult = isIDValid
+      
+    case .updateUserId(let id):
+      newState.userId = id
 
     case .validateNextButton(let isNextButtonEnabled):
       newState.isNextButtonEnabled = isNextButtonEnabled
+      
+    case .updateLoading(let isLoading):
+      newState.isLoading = isLoading
     }
     
     return newState

--- a/Favor/Favor/Sources/Scenes/Auth/Reactors/SetProfileViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/Reactors/SetProfileViewReactor.swift
@@ -93,18 +93,21 @@ final class SetProfileViewReactor: Reactor, Stepper {
         let userId = self.currentState.userId
         let userName = self.currentState.userName
         
+        // TODO: 로컬 데이터로 User Infomation을 저장해야함.
+        
         return .concat([
           .just(.updateLoading(true)),
-
-          // TODO: Profile Networking
-//          networking.request(.patchProfile(
-//            userId: <#T##String#>,
-//            name: <#T##String#>,
-//            userNo: <#T##Int#>
-//          ))
-          
+          networking.request(.patchProfile(
+            userId: userId,
+            name: userName,
+            userNo: 0
+          ))
+          .debug()
+          .flatMap { _ -> Observable<Mutation> in
+            self.steps.accept(AppStep.termIsRequired(self.currentState.userName))
+            return .just(.updateLoading(false))
+          }
         ])
-        self.steps.accept(AppStep.termIsRequired(self.currentState.userName))
       }
       return .empty()
     }

--- a/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SetProfileVC.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SetProfileVC.swift
@@ -211,6 +211,10 @@ final class SetProfileViewController: BaseViewController, View {
         owner.nextButton.isEnabled = isEnabled
       })
       .disposed(by: self.disposeBag)
+    
+    reactor.state.map { $0.isLoading }
+      .bind(to: self.rx.isLoading)
+      .disposed(by: self.disposeBag)
   }
   
   // MARK: - Functions

--- a/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SignUpVC.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SignUpVC.swift
@@ -164,7 +164,7 @@ final class SignUpViewController: BaseViewController, View {
       .map { Reactor.Action.confirmPasswordTextFieldDidUpdate($0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
-
+    
     self.pwValidateTextField.rx.editingDidBegin
       .bind(with: self, onNext: { owner, _ in
         owner.scrollView.scroll(to: owner.pwTextField.frame.maxY - Metric.topSpacing)

--- a/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SignUpVC.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/ViewControllers/SignUpVC.swift
@@ -214,7 +214,7 @@ final class SignUpViewController: BaseViewController, View {
         }
       })
       .disposed(by: self.disposeBag)
-
+    
     reactor.state.map { $0.passwordValidationResult }
       .asDriver(onErrorJustReturn: .valid)
       .distinctUntilChanged()
@@ -263,6 +263,10 @@ final class SignUpViewController: BaseViewController, View {
           button.isEnabled = (isButtonEnabled == true)
         }
       })
+      .disposed(by: self.disposeBag)
+    
+    reactor.state.map { $0.isLoading }
+      .bind(to: self.rx.isLoading)
       .disposed(by: self.disposeBag)
   }
   

--- a/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
@@ -1,0 +1,36 @@
+//
+//  BaseViewController+.swift
+//  
+//
+//  Created by 김응철 on 2023/03/17.
+//
+
+import UIKit
+
+import RxSwift
+
+private var spinnerView: UIView?
+
+extension Reactive where Base: BaseViewController {
+  
+  public var spinnerState: Binder<Bool> {
+    return Binder(self.base) { vc, isLoading in
+      let spinner = UIActivityIndicatorView()
+      spinner.color = .lightGray
+      
+      if isLoading {
+        guard spinnerView == nil else { return }
+        spinnerView = UIView(frame: vc.view.bounds)
+        spinnerView?.backgroundColor = .clear
+        spinnerView?.addSubview(spinner)
+        spinner.center = spinnerView!.center
+        spinner.startAnimating()
+        vc.view.addSubview(spinnerView!)
+      } else {
+        guard spinnerView != nil else { return }
+        spinnerView?.removeFromSuperview()
+        spinnerView = nil
+      }
+    }
+  }
+}

--- a/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
@@ -1,6 +1,6 @@
 //
 //  BaseViewController+.swift
-//  
+//  Favor
 //
 //  Created by 김응철 on 2023/03/17.
 //

--- a/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Extensions/BaseViewController+.swift
@@ -13,7 +13,7 @@ private var spinnerView: UIView?
 
 extension Reactive where Base: BaseViewController {
   
-  public var spinnerState: Binder<Bool> {
+  public var isLoading: Binder<Bool> {
     return Binder(self.base) { vc, isLoading in
       let spinner = UIActivityIndicatorView()
       spinner.color = .lightGray

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+Request.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking+Request.swift
@@ -5,8 +5,8 @@
 //  Created by 김응철 on 2023/03/14.
 //
 
-import RxSwift
 import Moya
+import RxSwift
 
 extension Networking {
   public func handleInternetConnection<T: Any>(_ error: Error) throws -> Single<T> {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/Networking.swift
@@ -32,18 +32,15 @@ public final class Networking<TargetType: BaseTargetType> {
   
   public func request(
     _ target: TargetType
-  ) -> Single<Response> {
+  ) -> Observable<Response> {
     let requestURL = "\(target.method.rawValue) \(target.path)"
     return self.provider.rx.request(target)
       .filterSuccessfulStatusCodes()
       .catch(self.handleInternetConnection)
       .catch(self.handleTimeOut)
       .catch(self.handleREST)
+      .asObservable()
       .do(
-        onSuccess: { value in
-          let message = "🌐 ⭕ SUCCESS: \(requestURL) [\(value.statusCode)]"
-          os_log(.debug, "\(message)")
-        },
         onError: { error in
           switch error {
           case APIError.internetConnection:


### PR DESCRIPTION
## ⚠️ 이슈 번호

> 브랜치에 할당된 이슈 번호
#94 

## ✌️ 구현/추가 사항

- `회원가입` 로직 구현
- `프로필 생성` 로직 구현 
- `request` 메서드 `asObservable`로 리턴 타입 변경 

- `isLoading` `Binder` `Extension` 구현
> 사용하는 쪽 
```swift
    reactor.state.map { $0.isLoading }
      .bind(to: self.rx.isLoading)
      .disposed(by: self.disposeBag)
```

## 💬 코멘트

- 서버에서 현재 로그인한 회원의 `userId`를 필수적으로 받고 있음
--> UserStorage라는 UserDefault를 이용하여 ResponseModel들을 저장하려고 했으나,
Relam을 이용할 예정이기 때문에 구현 해야하는지 고민.. 

> 추가한 기능에 대한 설명 및 리뷰 참고 사항
