### PR TITLE
[Feat] 친구 선택 페이지 추가 기능 구현 및 Diffable 리펙토링

### DIFF
--- a/Favor/Favor.xcodeproj/project.pbxproj
+++ b/Favor/Favor.xcodeproj/project.pbxproj
@@ -141,7 +141,6 @@
 		E524C19229E9A34B004CCC40 /* NewGiftFriendViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E524C19129E9A34B004CCC40 /* NewGiftFriendViewReactor.swift */; };
 		E524C19429EA4014004CCC40 /* NewGiftFriendCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E524C19329EA4014004CCC40 /* NewGiftFriendCell.swift */; };
 		E524C19629EAA50C004CCC40 /* NewGiftFriendHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E524C19529EAA50C004CCC40 /* NewGiftFriendHeaderView.swift */; };
-		E524C19A29EACC8D004CCC40 /* NewGiftFriendHeaderViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E524C19929EACC8D004CCC40 /* NewGiftFriendHeaderViewReactor.swift */; };
 		E52F565B29D5698A004E85A6 /* NewGiftFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52F565A29D5698A004E85A6 /* NewGiftFlow.swift */; };
 		E52F565D29D5CBAA004E85A6 /* NewGiftChoiceFriendButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52F565C29D5CBAA004E85A6 /* NewGiftChoiceFriendButton.swift */; };
 		E55CF7BA298A743B002940D1 /* AuthFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55CF7B9298A743B002940D1 /* AuthFlow.swift */; };
@@ -154,6 +153,7 @@
 		E562610F299497C000D14020 /* NewGiftViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E562610E299497C000D14020 /* NewGiftViewReactor.swift */; };
 		E57F313D2970004D00E3D449 /* OnboardingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57F313C2970004D00E3D449 /* OnboardingCell.swift */; };
 		E59AC13A29EEEB6E00FCE0C0 /* NewGiftFriendFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59AC13929EEEB6E00FCE0C0 /* NewGiftFriendFooterView.swift */; };
+		E5A18E7E2A0CC8700054CC53 /* NewGiftFriendHeaderViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A18E7D2A0CC8700054CC53 /* NewGiftFriendHeaderViewReactor.swift */; };
 		E5B1827A2973FDC600229C50 /* OnboardingSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B182792973FDC600229C50 /* OnboardingSlide.swift */; };
 		E5B61F3529B37F260031046C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E5CFF72B298404F700E11D9A /* AppStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CFF72A298404F700E11D9A /* AppStep.swift */; };
@@ -296,7 +296,6 @@
 		E524C19129E9A34B004CCC40 /* NewGiftFriendViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendViewReactor.swift; sourceTree = "<group>"; };
 		E524C19329EA4014004CCC40 /* NewGiftFriendCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendCell.swift; sourceTree = "<group>"; };
 		E524C19529EAA50C004CCC40 /* NewGiftFriendHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendHeaderView.swift; sourceTree = "<group>"; };
-		E524C19929EACC8D004CCC40 /* NewGiftFriendHeaderViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendHeaderViewReactor.swift; sourceTree = "<group>"; };
 		E52F565A29D5698A004E85A6 /* NewGiftFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFlow.swift; sourceTree = "<group>"; };
 		E52F565C29D5CBAA004E85A6 /* NewGiftChoiceFriendButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftChoiceFriendButton.swift; sourceTree = "<group>"; };
 		E55CF7B9298A743B002940D1 /* AuthFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlow.swift; sourceTree = "<group>"; };
@@ -308,6 +307,7 @@
 		E562610E299497C000D14020 /* NewGiftViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftViewReactor.swift; sourceTree = "<group>"; };
 		E57F313C2970004D00E3D449 /* OnboardingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCell.swift; sourceTree = "<group>"; };
 		E59AC13929EEEB6E00FCE0C0 /* NewGiftFriendFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendFooterView.swift; sourceTree = "<group>"; };
+		E5A18E7D2A0CC8700054CC53 /* NewGiftFriendHeaderViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewGiftFriendHeaderViewReactor.swift; sourceTree = "<group>"; };
 		E5B182792973FDC600229C50 /* OnboardingSlide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSlide.swift; sourceTree = "<group>"; };
 		E5CFF72A298404F700E11D9A /* AppStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStep.swift; sourceTree = "<group>"; };
 		E5E28ED3295DAE2C006B9245 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -916,7 +916,7 @@
 				E524C19029E9A31A004CCC40 /* CellReactros */,
 				E562610E299497C000D14020 /* NewGiftViewReactor.swift */,
 				E524C19129E9A34B004CCC40 /* NewGiftFriendViewReactor.swift */,
-				E524C19929EACC8D004CCC40 /* NewGiftFriendHeaderViewReactor.swift */,
+				E5A18E7D2A0CC8700054CC53 /* NewGiftFriendHeaderViewReactor.swift */,
 			);
 			path = Reactors;
 			sourceTree = "<group>";
@@ -1230,6 +1230,7 @@
 				E52F565B29D5698A004E85A6 /* NewGiftFlow.swift in Sources */,
 				2EA3849C298D7C680081499C /* UpcomingCell.swift in Sources */,
 				2EC939E72998C6D100C8C47F /* ProfileAnniversaryCell.swift in Sources */,
+				E5A18E7E2A0CC8700054CC53 /* NewGiftFriendHeaderViewReactor.swift in Sources */,
 				2ED326AD29B0DB9D001963D0 /* TermSection.swift in Sources */,
 				2EE07EE9296EDE9700048A3C /* SelectSignInViewReactor.swift in Sources */,
 				2EB3E71B29D5EB77008D10A0 /* PastSectionBackgroundView.swift in Sources */,
@@ -1239,7 +1240,6 @@
 				2E3FA75129F713A7003342CA /* EditMyPageCollectionHeaderView.swift in Sources */,
 				2EA38494298D7C5F0081499C /* HeaderViewReactor.swift in Sources */,
 				2E95E4B729E8FB8000A46C38 /* SearchUserResultCell.swift in Sources */,
-				2EA3849E298D7C680081499C /* HomeHeaderView.swift in Sources */,
 				2E76F58529601CD6002FF001 /* SplashVC.swift in Sources */,
 				2EE0D58329751EEF0064E932 /* SignUpViewReactor.swift in Sources */,
 				2EC939EF299BB10D00C8C47F /* ProfileSectionHeaderReactor.swift in Sources */,
@@ -1297,10 +1297,6 @@
 				2E32E7CB29FEB8E400202E31 /* EditMyPageSection.swift in Sources */,
 				2E95E4B329E8F01C00A46C38 /* SearchGiftResultCellReactor.swift in Sources */,
 				2EE0D585297524660064E932 /* SetProfileVC.swift in Sources */,
-				2EC939DF2998B80200C8C47F /* ProfileSection.swift in Sources */,
-				2EC939F9299E160B00C8C47F /* ProfileView.swift in Sources */,
-				2EC939DF2998B80200C8C47F /* ProfileSection.swift in Sources */,
-				2EC939F9299E160B00C8C47F /* ProfileView.swift in Sources */,
 				E524C18D29E93758004CCC40 /* NewGiftFriendEmptyCell.swift in Sources */,
 				2EB3E71129D4356A008D10A0 /* ReminderViewReactor.swift in Sources */,
 				2EBCC8FF29EDBFDB008044DC /* UICollectionViewCompositionalLayout+.swift in Sources */,
@@ -1313,7 +1309,6 @@
 				2EA38493298D7C5F0081499C /* TimelineCellReactor.swift in Sources */,
 				2E7C309E295D7C4300BAC43D /* SceneDelegate.swift in Sources */,
 				2EA3849A298D7C680081499C /* HomeSection.swift in Sources */,
-				E524C19A29EACC8D004CCC40 /* NewGiftFriendHeaderViewReactor.swift in Sources */,
 				2ED8CB4429B0BD3F00E7B547 /* TermViewReactor.swift in Sources */,
 				2EC939F7299CF6E800C8C47F /* ProfileAnniversaryCellReactor.swift in Sources */,
 				E57F313D2970004D00E3D449 /* OnboardingCell.swift in Sources */,

--- a/Favor/Favor/Sources/Scenes/Gift/NewGiftFriendSection.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/NewGiftFriendSection.swift
@@ -9,22 +9,7 @@ import UIKit
 
 import FavorKit
 
-enum NewGiftFriendSection: Hashable {
-  case selectedFriends
-  case friends
-  
-  /// 각 헤더의 높이 값 입니다.
-  var headerHeight: NSCollectionLayoutDimension {
-    switch self {
-    case .selectedFriends:
-      return .absolute(54)
-    case .friends:
-      return .absolute(100)
-    }
-  }
-}
-
-enum NewGiftFriendItem: Hashable {
+enum NewGiftFriendItem {
   case empty
   case friend(NewGiftFriendCellReactor)
   
@@ -34,6 +19,36 @@ enum NewGiftFriendItem: Hashable {
       return nil
     case .friend(let reactor):
       return reactor
+    }
+  }
+}
+
+enum NewGiftFriendSection: Int, SectionModelType {
+  case selectedFriends
+  case friends
+}
+
+// MARK: - Hashable
+
+extension NewGiftFriendItem: SectionModelItem {
+  static func == (lhs: NewGiftFriendItem, rhs: NewGiftFriendItem) -> Bool {
+    switch (lhs, rhs) {
+    case (.empty, .empty):
+      return true
+    case let (.friend(lhsReactor), .friend(rhsReactor)):
+      return lhsReactor === rhsReactor
+    default:
+      return false
+    }
+  }
+  
+  func hash(into hasher: inout Hasher) {
+    switch self {
+    case .empty:
+      hasher.combine(0)
+    case .friend(let reactor):
+      hasher.combine(1)
+      hasher.combine(ObjectIdentifier(reactor))
     }
   }
 }

--- a/Favor/Favor/Sources/Scenes/Gift/NewGiftFriendSection.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/NewGiftFriendSection.swift
@@ -23,7 +23,7 @@ enum NewGiftFriendItem {
   }
 }
 
-enum NewGiftFriendSection: Int, SectionModelType {
+enum NewGiftFriendSection: SectionModelType {
   case selectedFriends
   case friends
 }

--- a/Favor/Favor/Sources/Scenes/Gift/Reactors/CellReactros/NewGiftFriendCellReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Reactors/CellReactros/NewGiftFriendCellReactor.swift
@@ -10,17 +10,11 @@ import UIKit
 import FavorKit
 import ReactorKit
 
-final class NewGiftFriendCellReactor: Reactor, Hashable {
-  static func == (
-    lhs: NewGiftFriendCellReactor,
-    rhs: NewGiftFriendCellReactor
-  ) -> Bool {
-    return lhs.currentState == rhs.currentState
-  }
+final class NewGiftFriendCellReactor: Reactor {
   
   typealias Action = NoAction
   
-  struct State: Hashable {
+  struct State {
     var rightButtonState: NewGiftFriendCell.RightButtonType = .add
     var friend: Friend
   }

--- a/Favor/Favor/Sources/Scenes/Gift/Reactors/NewGiftFriendHeaderViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Reactors/NewGiftFriendHeaderViewReactor.swift
@@ -2,27 +2,28 @@
 //  NewGiftFriendHeaderViewReactor.swift
 //  Favor
 //
-//  Created by 김응철 on 2023/04/15.
+//  Created by 김응철 on 2023/05/11.
 //
+
+import FavorKit
 
 import ReactorKit
 
 final class NewGiftFriendHeaderViewReactor: Reactor {
   typealias Action = NoAction
-  
+
   struct State {
-    var sectionModel: NewGiftFriendSection.NewGiftFriendSectionModel
+    var section: NewGiftFriendSection
+    var friends: [Friend]
   }
   
   // MARK: - Properties
   
   var initialState: State
   
-  // MARK: - Initialzier
+  // MARK: - Initializer
   
-  init(sectionModel: NewGiftFriendSection.NewGiftFriendSectionModel) {
-    self.initialState = State(
-      sectionModel: sectionModel
-    )
+  init(_ section: NewGiftFriendSection, friends: [Friend]) {
+    self.initialState = State(section: section, friends: friends)
   }
 }

--- a/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
@@ -145,7 +145,7 @@ final class NewGiftFriendViewController: BaseViewController, View {
   override func setupStyles() {
     super.setupStyles()
     
-    self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.finishButton)
+    self.navigationItem.rightBarButtonItem = self.finishButton.toBarButtonItem()
   }
   
   override func setupLayouts() {
@@ -209,7 +209,6 @@ final class NewGiftFriendViewController: BaseViewController, View {
       .disposed(by: self.disposeBag)
     
     reactor.state.map { $0.isEnabledFinishButton }
-      .debug()
       .bind(to: self.finishButton.rx.isEnabled)
       .disposed(by: self.disposeBag)
   }

--- a/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
@@ -85,14 +85,12 @@ final class NewGiftFriendViewController: BaseViewController, View {
   // MARK: - UI Components
   
   // Navigation Items
-  private let doneButton: UIButton = {
+  private let finishButton: UIButton = {
     var config = UIButton.Configuration.plain()
     config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 4)
     config.attributedTitle = AttributedString(
       "완료",
-      attributes: .init([
-        .font: UIFont.favorFont(.bold, size: 18)
-      ])
+      attributes: .init([.font: UIFont.favorFont(.bold, size: 18)])
     )
     let btn = UIButton(configuration: config)
     btn.configurationUpdateHandler = {
@@ -105,6 +103,7 @@ final class NewGiftFriendViewController: BaseViewController, View {
         break
       }
     }
+    btn.isEnabled = false
     return btn
   }()
   
@@ -146,7 +145,7 @@ final class NewGiftFriendViewController: BaseViewController, View {
   override func setupStyles() {
     super.setupStyles()
     
-    self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
+    self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.finishButton)
   }
   
   override func setupLayouts() {
@@ -207,6 +206,11 @@ final class NewGiftFriendViewController: BaseViewController, View {
     
     reactor.state.map { $0.isLoading }
       .bind(to: self.rx.isLoading)
+      .disposed(by: self.disposeBag)
+    
+    reactor.state.map { $0.isEnabledFinishButton }
+      .debug()
+      .bind(to: self.finishButton.rx.isEnabled)
       .disposed(by: self.disposeBag)
   }
   

--- a/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/ViewControllers/NewGiftFriendVC.swift
@@ -13,13 +13,74 @@ import Reusable
 import RxDataSources
 
 final class NewGiftFriendViewController: BaseViewController, View {
+  typealias DataSource = UICollectionViewDiffableDataSource<NewGiftFriendSection, NewGiftFriendItem>
   
-  private enum Constants {
+  private enum Metric {
+    // Cell
     static let emptyCellHeight: CGFloat = 93.0
     static let friendCellHeight: CGFloat = 48.0
-    static let interGroupSpacing: CGFloat = 8.0
+
+    // SupplementaryView
     static let footerHeight: CGFloat = 91.0
+    static let selectedFriendsHeaderHeight: CGFloat = 54.0
+    static let friendsHeaderHeight: CGFloat = 100.0
+    
+    // Inset
+    static let interGroupSpacing: CGFloat = 8.0
+    static let topContentsInset: CGFloat = 16.0
   }
+  
+  // MARK: - Properties
+  
+  private lazy var dataSource: DataSource = {
+    let dataSource = DataSource(
+      collectionView: self.collectionView,
+      cellProvider: { collectionView, indexPath, item in
+        switch item {
+        case .empty:
+          let cell = collectionView.dequeueReusableCell(for: indexPath) as NewGiftFriendEmptyCell
+          return cell
+        case .friend(let reactor):
+          let cell = collectionView.dequeueReusableCell(for: indexPath) as NewGiftFriendCell
+          cell.reactor = reactor
+          return cell
+        }
+      }
+    )
+    dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in
+      guard let self = self, let reactor = self.reactor else {
+        return UICollectionReusableView()
+      }
+      switch kind {
+      case UICollectionView.elementKindSectionHeader:
+        let header = collectionView.dequeueReusableSupplementaryView(
+          ofKind: kind,
+          for: indexPath
+        ) as NewGiftFriendHeaderView
+        let section = self.dataSource.sectionIdentifier(for: indexPath.section) ?? .friends
+        let friends = section == .friends ?
+        reactor.allFriends :
+        reactor.currentState.selectedFriends
+        header.reactor = NewGiftFriendHeaderViewReactor(section, friends: friends)
+        // 서치바 이벤트
+        header.textFieldChanged = { [weak self] in
+          self?.reactor?.action.onNext(.textFieldDidChange($0))
+        }
+        
+        return header
+      case UICollectionView.elementKindSectionFooter:
+        let footer = collectionView.dequeueReusableSupplementaryView(
+          ofKind: kind,
+          for: indexPath
+        ) as NewGiftFriendFooterView
+        return footer
+      default:
+        return UICollectionReusableView()
+      }
+    }
+
+    return dataSource
+  }()
   
   // MARK: - UI Components
   
@@ -80,47 +141,6 @@ final class NewGiftFriendViewController: BaseViewController, View {
     return view
   }()
   
-  private var headerView: NewGiftFriendHeaderView?
-  
-  // MARK: - Properties
-  
-  private lazy var dataSource: DataSource = DataSource(
-    configureCell: { _, collectionView, indexPath, item in
-      switch item {
-      case .empty:
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as NewGiftFriendEmptyCell
-        return cell
-      case .friend(let reactor):
-        let cell = collectionView.dequeueReusableCell(for: indexPath) as NewGiftFriendCell
-        cell.reactor = reactor
-        return cell
-      }
-    },
-    configureSupplementaryView: { dataSource, collectionView, kind, indexPath in
-      let sectionModel = dataSource[indexPath.section]
-      
-      if kind == UICollectionView.elementKindSectionHeader {
-        // Header
-        let header = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          for: indexPath
-        ) as NewGiftFriendHeaderView
-        header.reactor = NewGiftFriendHeaderViewReactor(sectionModel: sectionModel)
-        header.textFieldChanged = { [weak self] in
-          self?.reactor?.action.onNext(.textFieldDidChange($0))
-        }
-        return header
-      } else {
-        // Footer
-        let footer = collectionView.dequeueReusableSupplementaryView(
-          ofKind: kind,
-          for: indexPath
-        ) as NewGiftFriendFooterView
-        return footer
-      }
-    }
-  )
-  
   // MARK: - Setup
   
   override func setupStyles() {
@@ -170,10 +190,19 @@ final class NewGiftFriendViewController: BaseViewController, View {
       .disposed(by: self.disposeBag)
     
     // State
-    reactor.state.map { [$0.selectedSection, $0.friendListSection] }
+    reactor.state.map { $0.items }
       .distinctUntilChanged()
-      .debug()
-      .bind(to: self.collectionView.rx.items(dataSource: dataSource))
+      .asDriver(onErrorJustReturn: [])
+      .drive(with: self, onNext: { owner, items in
+        var snapShot = NSDiffableDataSourceSnapshot<NewGiftFriendSection, NewGiftFriendItem>()
+        let sections: [NewGiftFriendSection] = [.selectedFriends, .friends]
+        snapShot.appendSections(sections)
+        snapShot.reloadSections([.selectedFriends])
+        items.enumerated().forEach { index, items in
+          snapShot.appendItems(items, toSection: sections[index])
+        }
+        owner.dataSource.apply(snapShot, animatingDifferences: false)
+      })
       .disposed(by: self.disposeBag)
     
     reactor.state.map { $0.isLoading }
@@ -195,51 +224,45 @@ private extension NewGiftFriendViewController {
   func setupCollectionViewLayout() -> UICollectionViewCompositionalLayout {
     return UICollectionViewCompositionalLayout(
       sectionProvider: { sectionIndex, _ in
-        let sectionModel = self.dataSource[sectionIndex]
-        let firstItem = sectionModel.items.first ?? .empty
-        var isEmptySelectedFriend: Bool = false
-        if case NewGiftFriendSection.NewGiftFriendSectionItem.empty = firstItem {
-          isEmptySelectedFriend = true
-        }
-        
+        let sections: [NewGiftFriendSection] = [.selectedFriends, .friends]
+        let sectionType = sections[sectionIndex]
+        let isEmptySelectedFriends: Bool = self.reactor?.currentState.selectedFriends.isEmpty ?? false
         return self.createCollectionViewLayout(
-          sectionType: sectionModel.model,
-          isEmptySelectedFriend: isEmptySelectedFriend
+          sectionType: sectionType,
+          isEmptySelectedFriends: isEmptySelectedFriends
         )
       }
     )
   }
   
   func createCollectionViewLayout(
-    sectionType: NewGiftFriendSectionType,
-    isEmptySelectedFriend: Bool
+    sectionType: NewGiftFriendSection,
+    isEmptySelectedFriends: Bool
   ) -> NSCollectionLayoutSection {
     let emptyItemSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .absolute(Constants.emptyCellHeight)
+      heightDimension: .absolute(Metric.emptyCellHeight)
     )
     let itemSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .absolute(Constants.friendCellHeight)
+      heightDimension: .absolute(Metric.friendCellHeight)
     )
-    
     let activeItemSize: NSCollectionLayoutSize
     let topContentInset: CGFloat
     let bottomContentInset: CGFloat
     
     switch sectionType {
     case .selectedFriends:
-      activeItemSize = isEmptySelectedFriend ? emptyItemSize : itemSize
+      activeItemSize = isEmptySelectedFriends ? emptyItemSize : itemSize
       topContentInset = 16.0
-      bottomContentInset = isEmptySelectedFriend ? 48.0 : 8.0
-    case .friendList:
+      bottomContentInset = isEmptySelectedFriends ? 48.0 : 8.0
+    case .friends:
       activeItemSize = itemSize
       topContentInset = 32.0
       bottomContentInset = 16.0
     }
     
     let item = NSCollectionLayoutItem(layoutSize: activeItemSize)
-    
     let group = NSCollectionLayoutGroup.vertical(
       layoutSize: NSCollectionLayoutSize(
         widthDimension: .fractionalWidth(1.0),
@@ -249,16 +272,16 @@ private extension NewGiftFriendViewController {
     )
     
     let section = NSCollectionLayoutSection(group: group)
-    section.interGroupSpacing = Constants.interGroupSpacing
+    section.interGroupSpacing = Metric.interGroupSpacing
     section.contentInsets = NSDirectionalEdgeInsets(
       top: topContentInset,
       leading: 0,
       bottom: bottomContentInset,
       trailing: 0
     )
-    section.boundarySupplementaryItems = [self.createHeader(sectionType: sectionType)]
+    section.boundarySupplementaryItems = [self.createHeader(section: sectionType)]
     
-    if sectionType == .friendList {
+    if sectionType == .friends {
       section.boundarySupplementaryItems.append(contentsOf: [self.createFooter()])
     }
     return section
@@ -266,12 +289,18 @@ private extension NewGiftFriendViewController {
   
   // 헤더 생성
   func createHeader(
-    sectionType: NewGiftFriendSectionType
+    section: NewGiftFriendSection
   ) -> NSCollectionLayoutBoundarySupplementaryItem {
+    let height: CGFloat
+    switch section {
+    case .selectedFriends: height = Metric.selectedFriendsHeaderHeight
+    case .friends: height = Metric.friendsHeaderHeight
+    }
+    
     let header = NSCollectionLayoutBoundarySupplementaryItem(
       layoutSize: NSCollectionLayoutSize(
         widthDimension: .fractionalWidth(1.0),
-        heightDimension: sectionType.headerHeight
+        heightDimension: .absolute(height)
       ),
       elementKind: UICollectionView.elementKindSectionHeader,
       alignment: .top
@@ -279,10 +308,11 @@ private extension NewGiftFriendViewController {
     return header
   }
   
+  // 푸터 생성
   func createFooter() -> NSCollectionLayoutBoundarySupplementaryItem {
     let footerSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .absolute(Constants.footerHeight)
+      heightDimension: .absolute(Metric.footerHeight)
     )
     let footer = NSCollectionLayoutBoundarySupplementaryItem(
       layoutSize: footerSize,

--- a/Favor/Favor/Sources/Scenes/Gift/Views/Cells/NewGiftFriendCell.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Views/Cells/NewGiftFriendCell.swift
@@ -23,7 +23,7 @@ final class NewGiftFriendCell: BaseFriendCell, View, Reusable {
   
   private let rightImageView: UIImageView = {
     let iv = UIImageView()
-    iv.image = .favorIcon(.newGift)?.withTintColor(.favorColor(.line3))
+    iv.image = .favorIcon(.newGift)?.withTintColor(.favorColor(.divider))
     return iv
   }()
   
@@ -34,11 +34,11 @@ final class NewGiftFriendCell: BaseFriendCell, View, Reusable {
       let image: UIImage?
       switch currentButtonType {
       case .add:
-        image = .favorIcon(.newGift)?.withTintColor(.favorColor(.line3))
+        image = .favorIcon(.newGift)?.withTintColor(.favorColor(.divider))
       case .remove:
-        image = .favorIcon(.remove)?.withTintColor(.favorColor(.line3))
+        image = .favorIcon(.remove)?.withTintColor(.favorColor(.divider))
       case .done:
-        image = .favorIcon(.done)?.withTintColor(.favorColor(.line3))
+        image = .favorIcon(.done)?.withTintColor(.favorColor(.divider))
       }
       self.rightImageView.image = image
     }

--- a/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
@@ -67,27 +67,24 @@ final class NewGiftFriendHeaderView: UICollectionReusableView, Reusable, View {
       .disposed(by: self.disposeBag)
     
     // State
-    reactor.state.map { $0.sectionModel }
+    reactor.state.map { $0.section }
       .asDriver(onErrorRecover: { _ in return .empty() })
-      .drive(with: self) { owner, sectionModel in
-        switch sectionModel.model {
-        case .friendList:
-          owner.titleLabel.text = "친구"
-          owner.searchBar.isHidden = false
+      .drive(with: self) { owner, section in
+        switch section {
         case .selectedFriends:
           owner.titleLabel.text = "선택한 친구"
           owner.searchBar.isHidden = true
+        case .friends:
+          owner.titleLabel.text = "친구"
+          owner.searchBar.isHidden = false
         }
-        
-        var count: Int = 0
-        sectionModel.items.forEach {
-          switch $0 {
-          case .empty:
-            break
-          case .friend:
-            count += 1
-          }
-        }
+      }
+      .disposed(by: self.disposeBag)
+    
+    reactor.state.map { $0.friends }
+      .asDriver(onErrorRecover: { _ in return .empty() })
+      .drive(with: self) { owner, friends in
+        let count: Int = friends.count
         owner.countLabel.text = "\(count)"
       }
       .disposed(by: self.disposeBag)

--- a/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
@@ -62,7 +62,6 @@ final class NewGiftFriendHeaderView: UICollectionReusableView, Reusable, View {
       .orEmpty
       .asDriver()
       .skip(1)
-      .debug()
       .drive(with: self) { $0.textFieldChanged?($1) }
       .disposed(by: self.disposeBag)
     

--- a/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
+++ b/Favor/Favor/Sources/Scenes/Gift/Views/NewGiftFriendHeaderView.swift
@@ -58,10 +58,9 @@ final class NewGiftFriendHeaderView: UICollectionReusableView, Reusable, View {
   
   func bind(reactor: NewGiftFriendHeaderViewReactor) {
     // Action
-    self.searchBar.rx.text
-      .orEmpty
+    self.searchBar.rx.text.orEmpty
       .asDriver()
-      .skip(1)
+      .skip(2)
       .drive(with: self) { $0.textFieldChanged?($1) }
       .disposed(by: self.disposeBag)
     

--- a/Favor/Favor/Sources/Scenes/Profile/EditMyPage/ViewControllers/EditMyPageVC.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/EditMyPage/ViewControllers/EditMyPageVC.swift
@@ -22,7 +22,7 @@ final class EditMyPageViewController: BaseViewController, View {
   }
 
   // MARK: - Properties
-
+  
   private lazy var dataSource: EditMyPageDataSource = {
     let dataSource = EditMyPageDataSource(
       collectionView: self.collectionView,
@@ -74,7 +74,7 @@ final class EditMyPageViewController: BaseViewController, View {
     }
     return dataSource
   }()
-
+  
   private lazy var adapter: Adapter<EditMyPageSection, EditMyPageSectionItem> = {
     let adapter = Adapter(collectionView: self.collectionView, dataSource: self.dataSource)
     adapter.configuration = Adapter.Configuration(
@@ -95,7 +95,7 @@ final class EditMyPageViewController: BaseViewController, View {
   }()
 
   // MARK: - UI Components
-
+  
   private let cancelButton: UIButton = {
     var config = UIButton.Configuration.plain()
     config.updateAttributedTitle("취소", font: .favorFont(.bold, size: 18))
@@ -121,7 +121,7 @@ final class EditMyPageViewController: BaseViewController, View {
       frame: .zero,
       collectionViewLayout: UICollectionViewLayout()
     )
-
+    
     // Register
     collectionView.register(cellType: FavorTextFieldCell.self)
     collectionView.register(cellType: EditMyPageFavorCell.self)
@@ -162,16 +162,16 @@ final class EditMyPageViewController: BaseViewController, View {
 
   override func bind() {
     guard let reactor = self.reactor else { return }
-
+    
     // Action
     self.collectionView.rx.itemSelected
       .map { Reactor.Action.favorDidSelected($0.item) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
-
+    
     // State
     reactor.state.map { (sections: $0.sections, items: $0.items) }
-      .asDriver(onErrorRecover: { _ in return .empty()})
+      .asDriver(onErrorRecover: { _ in return .empty() })
       .drive(with: self, onNext: { owner, sectionData in
         var snapshot: NSDiffableDataSourceSnapshot<EditMyPageSection, EditMyPageSectionItem> = .init()
         snapshot.appendSections(sectionData.sections)

--- a/Favor/Favor/Sources/Scenes/Profile/MyPage/Reactors/MyPageViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/MyPage/Reactors/MyPageViewReactor.swift
@@ -108,7 +108,7 @@ final class MyPageViewReactor: Reactor, Stepper {
 
     case .updateUserName(let name):
       newState.userName = name
-
+      
     case .updateUserID(let id):
       newState.userID = id
 
@@ -136,14 +136,14 @@ final class MyPageViewReactor: Reactor, Stepper {
 
     return newState
   }
-
+  
   func transform(state: Observable<State>) -> Observable<State> {
     return state.map { state in
       var newState = state
       var newSections: [ProfileSection] = []
       var newItems: [[ProfileSectionItem]] = []
       var profileSetupHelperItems: [ProfileSectionItem] = []
-
+      
       // 취향
       if !state.favorItems.isEmpty {
         newSections.append(.favors)

--- a/Favor/Favor/Sources/Scenes/Profile/MyPage/ViewControllers/MyPageVC.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/MyPage/ViewControllers/MyPageVC.swift
@@ -30,7 +30,7 @@ final class MyPageViewController: BaseProfileViewController, View {
     let button = UIButton(configuration: config)
     return button
   }()
-
+  
   private let settingButton: UIButton = {
     var config = UIButton.Configuration.plain()
     config.image = .favorIcon(.setting)?.withRenderingMode(.alwaysTemplate)
@@ -47,7 +47,7 @@ final class MyPageViewController: BaseProfileViewController, View {
 
   override func bind() {
     guard let reactor = self.reactor else { return }
-
+    
     // Action
     self.collectionView.rx.contentOffset
       .asDriver(onErrorRecover: { _ in return .empty()})
@@ -55,7 +55,7 @@ final class MyPageViewController: BaseProfileViewController, View {
         owner.updateProfileViewLayout(by: offset)
       })
       .disposed(by: self.disposeBag)
-
+    
     // State
     reactor.state.map { (sections: $0.sections, items: $0.items) }
       .asDriver(onErrorRecover: { _ in return .empty()})

--- a/Favor/FavorKit/Sources/FavorKit/Components/CollectionView/FavorCompositionalLayout.swift
+++ b/Favor/FavorKit/Sources/FavorKit/Components/CollectionView/FavorCompositionalLayout.swift
@@ -10,7 +10,7 @@ import UIKit
 public final class FavorCompositionalLayout: UICollectionViewCompositionalLayout {
 
   // MARK: - Item
-
+  
   /// Item의 타입과 그에 따른 값들을 정의해둔 enum입니다.
   public enum Item {
 


### PR DESCRIPTION
## ⚠️ 이슈 번호

> 브랜치에 할당된 이슈 번호
#120 

## ✌️ 구현/추가 사항

https://github.com/Favor-Gift-Reminder/Favor-iOS/assets/97531269/16e2ff58-2131-4ed8-b5c4-f674be2b1808

- 친구 검색 기능 구현
- 완료 버튼 활성/비활성화 구현
- RxDataSource -> DiffableDataSource로 구현
  - 섹션을 모두 리로드 하지 않아서 다양한 작업이 가능해짐 

## 💬 코멘트

일단 형이 구현해준 `FavorCompositionalLayout`을 사용해보려고 했는데
이 페이지 같은 경우에는 Layout이 하나로 고정되어 있지 않고,
친구가 선택되어 있지 않으면 `Cell`의 `Height`도 바뀌어버려서 `Adapter`로 어떻게 적용시켜줄지 조금 애매하더라고.. 
혹시 이 방법에 대해서 아는 게 있으면 코멘트 남겨줘 ! 