### PR TITLE
[Hotfix] 서버 재배포 이후 API 수정

### DIFF
--- a/Favor/Favor/Sources/Scenes/Anniversary/Reactors/AnniversaryManagementViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Anniversary/Reactors/AnniversaryManagementViewReactor.swift
@@ -164,8 +164,8 @@ private extension AnniversaryManagementViewReactor {
     return Single<Anniversary>.create { single in
       let networking = AnniversaryNetworking()
       let requestDTO = anniversary.requestDTO()
-
-      let disposable = networking.request(.postAnniversary(requestDTO, userNo: UserInfoStorage.userNo))
+      
+      let disposable = networking.request(.postAnniversary(requestDTO))
         .asSingle()
         .subscribe(onSuccess: { response in
           do {

--- a/Favor/Favor/Sources/Scenes/AnniversaryList/Reactors/BaseAnniversaryListViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/AnniversaryList/Reactors/BaseAnniversaryListViewReactor.swift
@@ -55,7 +55,7 @@ public class BaseAnniversaryListViewReactor {
     // onRemote
     self.userFetcher.onRemote = {
       let networking = UserNetworking()
-      let user = networking.request(.getUser(userNo: UserInfoStorage.userNo))
+      let user = networking.request(.getUser)
         .flatMap { user -> Observable<[User]> in
           let userData = user.data
           do {

--- a/Favor/Favor/Sources/Scenes/Auth/Profile/Reactors/AuthSetProfileViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/Profile/Reactors/AuthSetProfileViewReactor.swift
@@ -156,7 +156,7 @@ private extension AuthSetProfileViewReactor {
     return Single<User>.create { single in
       let networking = UserNetworking()
       let disposable = networking.request(
-        .patchProfile(userId: user.searchID, name: user.name, userNo: user.identifier))
+        .patchProfile(userId: user.searchID, name: user.name))
         .take(1)
         .asSingle()
         .subscribe(onSuccess: { response in

--- a/Favor/Favor/Sources/Scenes/Auth/SignIn/Reactors/AuthSignInViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Auth/SignIn/Reactors/AuthSignInViewReactor.swift
@@ -94,7 +94,7 @@ public final class AuthSignInViewReactor: Reactor, Stepper {
           .flatMap { token -> Observable<Mutation> in
             do {
               try self.handleSignInSuccess(email: email, password: password, token: token)
-              self.steps.accept(AppStep.dashboardIsRequired)
+              self.steps.accept(AppStep.authIsComplete)
             } catch {
               os_log(.error, "\(error)")
             }
@@ -107,7 +107,7 @@ public final class AuthSignInViewReactor: Reactor, Stepper {
             return .just(.updateLoading(false))
           }
       ])
-
+      
     case .findPasswordButtonDidTap:
       self.steps.accept(AppStep.findPasswordIsRequired)
       return .empty()

--- a/Favor/Favor/Sources/Scenes/FriendList/Reactors/BaseFriendListViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/FriendList/Reactors/BaseFriendListViewReactor.swift
@@ -29,7 +29,7 @@ public class BaseFriendListViewReactor {
     // onRemote
     self.friendFetcher.onRemote = {
       let networking = UserNetworking()
-      let friends = networking.request(.getAllFriendList(userNo: UserInfoStorage.userNo))
+      let friends = networking.request(.getAllFriendList)
         .flatMap { friends -> Observable<[Friend]> in
           do {
             let responseDTO: ResponseDTO<[FriendResponseDTO]> = try APIManager.decode(friends.data)

--- a/Favor/Favor/Sources/Scenes/GiftManagement/Reactors/GiftManagementViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/GiftManagement/Reactors/GiftManagementViewReactor.swift
@@ -213,7 +213,7 @@ private extension GiftManagementViewReactor {
       let networking = GiftNetworking()
       let requestDTO = gift.requestDTO()
 
-      let disposable = networking.request(.postGift(requestDTO, userNo: UserInfoStorage.userNo))
+      let disposable = networking.request(.postGift(requestDTO))
         .asSingle()
         .subscribe(with: self, onSuccess: { _, response in
           do {
@@ -229,7 +229,7 @@ private extension GiftManagementViewReactor {
       }
     }
   }
-
+  
   func requestPatchGift(_ gift: Gift) -> Single<Gift> {
     return Single<Gift>.create { single in
       let networking = GiftNetworking()

--- a/Favor/Favor/Sources/Scenes/GiftManagement/Reactors/NewGiftFriendViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/GiftManagement/Reactors/NewGiftFriendViewReactor.swift
@@ -166,7 +166,7 @@ private extension NewGiftFriendViewReactor {
     // onRemote
     self.friendFetcher.onRemote = {
       let networking = UserNetworking()
-      let friends = networking.request(.getAllFriendList(userNo: UserInfoStorage.userNo))
+      let friends = networking.request(.getAllFriendList)
         .flatMap { response -> Observable<[Friend]> in
           let responseDTO: ResponseDTO<[FriendResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Friend(dto: $0) })

--- a/Favor/Favor/Sources/Scenes/Home/Reactors/HomeViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Home/Reactors/HomeViewReactor.swift
@@ -226,7 +226,7 @@ private extension HomeViewReactor {
     // onRemote
     self.reminderFetcher.onRemote = {
       let networking = UserNetworking()
-      let reminders = networking.request(.getAllReminderList(userNo: UserInfoStorage.userNo))
+      let reminders = networking.request(.getAllReminderList)
         .flatMap { response -> Observable<[Reminder]> in
           let responseDTO: ResponseDTO<[ReminderResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Reminder(dto: $0) })
@@ -257,7 +257,7 @@ private extension HomeViewReactor {
     // onRemote
     self.giftFetcher.onRemote = {
       let networking = UserNetworking()
-      let gifts = networking.request(.getAllGifts(userNo: UserInfoStorage.userNo))
+      let gifts = networking.request(.getAllGifts)
         .flatMap { response -> Observable<[Gift]> in
           let responseDTO: ResponseDTO<[GiftResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Gift(dto: $0) })

--- a/Favor/Favor/Sources/Scenes/Profile/EditMyPage/Reactors/EditMyPageViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/EditMyPage/Reactors/EditMyPageViewReactor.swift
@@ -82,8 +82,7 @@ final class EditMyPageViewReactor: Reactor, Stepper {
       return self.userNetworking.request(.patchUser(
         name: name ?? currentState.user.name,
         userId: id ?? currentState.user.searchID,
-        favorList: favors,
-        userNo: UserInfoStorage.userNo
+        favorList: favors
       ))
       .flatMap { _ -> Observable<Mutation> in
         self.steps.accept(AppStep.editMyPageIsComplete)

--- a/Favor/Favor/Sources/Scenes/Profile/FriendPage/Reactors/FriendPageViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/FriendPage/Reactors/FriendPageViewReactor.swift
@@ -186,9 +186,8 @@ private extension FriendPageViewReactor {
     self.friendPatchFetcher.onRemote = {
       
       let networking = FriendNetworking()
-      let friend = networking.request(.patchFriend(
-        friendName: self.currentState.friend.name,
-        friendMemo: self.currentState.friend.memo ?? "",
+      let friend = networking.request(.patchFriendMemo(
+        memo: self.currentState.friend.memo ?? "",
         friendNo: self.currentState.friend.identifier
       ))
         .flatMap { response -> Observable<[Friend]> in

--- a/Favor/Favor/Sources/Scenes/Profile/MyPage/Reactors/MyPageViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Profile/MyPage/Reactors/MyPageViewReactor.swift
@@ -216,7 +216,7 @@ private extension MyPageViewReactor {
     // onRemote
     self.userFetcher.onRemote = {
       let networking = UserNetworking()
-      let user = networking.request(.getUser(userNo: UserInfoStorage.userNo))
+      let user = networking.request(.getUser)
         .flatMap { user -> Observable<[User]> in
           do {
             let responseDTO: ResponseDTO<UserResponseDTO> = try APIManager.decode(user.data)

--- a/Favor/Favor/Sources/Scenes/Reminder/Reactor/ReminderViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Reminder/Reactor/ReminderViewReactor.swift
@@ -136,7 +136,7 @@ private extension ReminderViewReactor {
     // onRemote
     self.reminderFetcher.onRemote = {
       let networking =  UserNetworking()
-      let reminders = networking.request(.getAllReminderList(userNo: UserInfoStorage.userNo))
+      let reminders = networking.request(.getAllReminderList)
         .flatMap { reminders -> Observable<[Reminder]> in
           let responseData = reminders.data
           do {

--- a/Favor/Favor/Sources/Scenes/Search/Reactors/SearchTagViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Search/Reactors/SearchTagViewReactor.swift
@@ -118,7 +118,7 @@ private extension SearchTagViewReactor {
     // onRemote
     self.giftFetcher.onRemote = {
       let networking = UserNetworking()
-      let gifts = networking.request(.getGiftByCategory(category: category.rawValue, userNo: UserInfoStorage.userNo))
+      let gifts = networking.request(.getGiftByCategory(category: category.rawValue))
         .flatMap { response -> Observable<[Gift]> in
           let responseDTO: ResponseDTO<[GiftResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Gift(dto: $0) })
@@ -144,7 +144,7 @@ private extension SearchTagViewReactor {
     // onRemote
     self.giftFetcher.onRemote = {
       let networking = UserNetworking()
-      let gifts = networking.request(.getGiftByEmotion(emotion: emotion.rawValue, userNo: UserInfoStorage.userNo))
+      let gifts = networking.request(.getGiftByEmotion(emotion: emotion.rawValue))
         .flatMap { response -> Observable<[Gift]> in
           let responseDTO: ResponseDTO<[GiftResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Gift(dto: $0) })

--- a/Favor/Favor/Sources/Scenes/Search/Reactors/SearchViewReactor.swift
+++ b/Favor/Favor/Sources/Scenes/Search/Reactors/SearchViewReactor.swift
@@ -322,7 +322,7 @@ private extension SearchViewReactor {
     // onRemote
     self.giftFetcher.onRemote = {
       let networking = UserNetworking()
-      let gifts = networking.request(.getGiftByName(giftName: queryString, userNo: UserInfoStorage.userNo))
+      let gifts = networking.request(.getGiftByName(giftName: queryString))
         .flatMap { response -> Observable<[Gift]> in
           let responseDTO: ResponseDTO<[GiftResponseDTO]> = try APIManager.decode(response.data)
           return .just(responseDTO.data.map { Gift(dto: $0) })

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Method.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Method.swift
@@ -26,6 +26,9 @@ extension AnniversaryAPI {
 
     case .postAnniversary:
       return .post
+      
+    case .patchAnniversaryPin:
+      return .patch
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Path.swift
@@ -26,6 +26,9 @@ extension AnniversaryAPI {
 
     case .postAnniversary:
       return "/anniversaries"
+      
+    case .patchAnniversaryPin(let anniversaryNo):
+      return "/anniversaries/pin/\(anniversaryNo)"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Path.swift
@@ -13,7 +13,7 @@ extension AnniversaryAPI {
   public func getPath() -> String {
     switch self {
     case .getAnniversaries:
-      return "/anniversaries"
+      return "/anniversaries/admin"
 
     case .getAnniversary(let anniversaryNo):
       return "/anniversaries/\(anniversaryNo)"
@@ -24,8 +24,8 @@ extension AnniversaryAPI {
     case .patchAnniversary(_, let anniversaryNo):
       return "/anniversaries/\(anniversaryNo)"
 
-    case .postAnniversary(_, let userNo):
-      return "/anniversaries/\(userNo)"
+    case .postAnniversary:
+      return "/anniversaries"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Task.swift
@@ -32,6 +32,9 @@ extension AnniversaryAPI {
       
     case let .postAnniversary(anniversaryRequestDTO):
       return .requestJSONEncodable(anniversaryRequestDTO)
+      
+    case .patchAnniversaryPin:
+      return .requestPlain
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI+Task.swift
@@ -29,15 +29,9 @@ extension AnniversaryAPI {
           "anniversaryNo": anniversaryNo
         ]
       )
-
-    case let .postAnniversary(anniversaryRequestDTO, userNo):
-      return .requestCompositeParameters(
-        bodyParameters: anniversaryRequestDTO.toDictionary(),
-        bodyEncoding: JSONEncoding.default,
-        urlParameters: [
-          "userNo": userNo
-        ]
-      )
+      
+    case let .postAnniversary(anniversaryRequestDTO):
+      return .requestJSONEncodable(anniversaryRequestDTO)
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI.swift
@@ -46,8 +46,7 @@ public enum AnniversaryAPI {
   /// ```
   /// - Parameters:
   ///   - dto: 생성하는 기념일에 대한 정보를 담은 `AnniversaryRequestDTO` - `Body`
-  ///   - userNo: 기념일을 생성하는 회원의 DB 넘버 - `Path`
-  case postAnniversary(AnniversaryRequestDTO, userNo: Int)
+  case postAnniversary(AnniversaryRequestDTO)
 }
 
 extension AnniversaryAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Anniversary/AnniversaryAPI.swift
@@ -20,7 +20,7 @@ public enum AnniversaryAPI {
 
   /// 기념일 삭제
   /// - Parameters:
-  ///   - 삭제하는 기념일의 DB 넘버 - `Path`
+  ///   - anniversaryNo: 삭제하는 기념일의 DB 넘버 - `Path`
   case deleteAnniversary(anniversaryNo: Int)
 
   /// 기념일 수정
@@ -47,6 +47,11 @@ public enum AnniversaryAPI {
   /// - Parameters:
   ///   - dto: 생성하는 기념일에 대한 정보를 담은 `AnniversaryRequestDTO` - `Body`
   case postAnniversary(AnniversaryRequestDTO)
+  
+  /// 기념일 핀 여부 수정
+  /// - Parameters:
+  ///  - annivesaryNo: 수정하는 기념일의 DB 넘버 - `Path`
+  case patchAnniversaryPin(anniversaryNo: Int)
 }
 
 extension AnniversaryAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Method.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Method.swift
@@ -21,7 +21,7 @@ extension FriendAPI {
     case .deleteFriend:
       return .delete
 
-    case .patchFriend:
+    case .patchFriendMemo:
       return .patch
 
     case .postFriend:
@@ -29,6 +29,15 @@ extension FriendAPI {
 
     case .postUserFriend:
       return .post
+      
+    case .getFriendGivenGifts:
+      return .get
+      
+    case .getFriendReceivedGifts:
+      return .get
+      
+    case .getFriendTotalGifts:
+      return .get
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Path.swift
@@ -13,7 +13,7 @@ extension FriendAPI {
   public func getPath() -> String {
     switch self {
     case .getAllFriends:
-      return "/friends"
+      return "/friends/admin"
 
     case .getFriend(let friendNo):
       return "/friends/\(friendNo)"
@@ -26,9 +26,9 @@ extension FriendAPI {
 
     case .postFriend(_, _, let userNo):
       return "/friends/\(userNo)"
-
-    case .postUserFriend(_, _, let userNo):
-      return "/friends/add/\(userNo)"
+      
+    case .postUserFriend:
+      return "/friends"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Path.swift
@@ -21,7 +21,7 @@ extension FriendAPI {
     case .deleteFriend(let friendNo):
       return "/friends/\(friendNo)"
 
-    case .patchFriend(_, _, let friendNo):
+    case let .patchFriendMemo(_, friendNo):
       return "/friends/\(friendNo)"
 
     case .postFriend(_, _, let userNo):
@@ -29,6 +29,15 @@ extension FriendAPI {
       
     case .postUserFriend:
       return "/friends"
+      
+    case .getFriendGivenGifts(let friendNo):
+      return "/friends/given-gifts/\(friendNo)"
+      
+    case .getFriendReceivedGifts(let friendNo):
+      return "/friends/received-gifts/\(friendNo)"
+
+    case .getFriendTotalGifts(let friendNo):
+      return "/friends/total-gifts/\(friendNo)"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Task.swift
@@ -39,11 +39,10 @@ extension FriendAPI {
         encoding: JSONEncoding.default
       )
       
-    case .postUserFriend(let userFriendNo, let userFriendMemo, _):
+    case .postUserFriend(let userFriendNo):
       return .requestParameters(
         parameters: [
-          "userFriendNo": userFriendNo,
-          "userFriendMemo": userFriendMemo
+          "userFriendNo": userFriendNo
         ],
         encoding: JSONEncoding.default
       )

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI+Task.swift
@@ -21,11 +21,10 @@ extension FriendAPI {
     case .deleteFriend:
       return .requestPlain
 
-    case .patchFriend(let friendName, let friendMemo, _):
+    case .patchFriendMemo(let memo, _):
       return .requestParameters(
         parameters: [
-          "friendName": friendName,
-          "friendMemo": friendMemo
+          "memo": memo
         ],
         encoding: JSONEncoding.default
       )
@@ -46,6 +45,15 @@ extension FriendAPI {
         ],
         encoding: JSONEncoding.default
       )
+      
+    case .getFriendGivenGifts:
+      return .requestPlain
+      
+    case .getFriendReceivedGifts:
+      return .requestPlain
+      
+    case .getFriendTotalGifts:
+      return .requestPlain
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI.swift
@@ -49,21 +49,24 @@ public enum FriendAPI {
   ///   - friendName: 추가하는 친구의 이름 - `Body`
   ///   - friendMemo: 추가하는 친구의 메모 - `Body`
   ///   - friendNo: 추가하는 친구의 DB 넘버 - `Path`
+  @available(
+    *,
+     deprecated,
+     renamed: "postUserFriend",
+     message: "비회원 친구추가 API는 삭제되었습니다. 대신 `postUserFriend`을 이용하세요."
+  )
   case postFriend(friendName: String, friendMemo: String, userNo: Int)
-
+  
   /// 회원친구 추가
   /// ``` json
   /// // friendRequestDTO
   /// {
   ///   "userFriendNo": 1,
-  ///   "userFriendMemo": "메모",
   /// }
   /// ```
   /// - Parameters:
   ///   - userFriendNo: 추가하는 유저 친구의 친구 목록 넘버 - `Body`
-  ///   - userFriendMemo: 추가하는 유저 친구의 메모 - `Body`
-  ///   - userNo: 추가하는 친구의 회원 DB 넘버 - `Path`
-  case postUserFriend(userFriendNo: Int, userFriendMemo: String, userNo: Int)
+  case postUserFriend(userFriendNo: Int)
 }
 
 extension FriendAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Friend/FriendAPI.swift
@@ -23,20 +23,18 @@ public enum FriendAPI {
   ///   - friendNo: 삭제하는 친구의 DB 넘버 - `Path`
   case deleteFriend(friendNo: Int)
 
-  /// 친구 수정
+  /// 친구 메모 수정
   /// ``` json
   /// // friendRequestDTO
   /// {
-  ///   "friendName": "이름",
-  ///   "friendMemo": "메모",
+  ///   "memo": "메모수정완료",
   /// }
   /// ```
   /// - Parameters:
-  ///   - friendName: 수정하는 친구의 이름 - `Body`
-  ///   - friendMemo: 수정하는 친구의 메모 - `Body`
+  ///   - memo: 수정하는 친구의 메모 - `Body`
   ///   - friendNo: 수정하는 친구의 DB 넘버 - `Path`
-  case patchFriend(friendName: String, friendMemo: String, friendNo: Int)
-
+  case patchFriendMemo(memo: String, friendNo: Int)
+  
   /// 친구 생성
   /// ``` json
   /// // friendRequestDTO
@@ -67,6 +65,22 @@ public enum FriendAPI {
   /// - Parameters:
   ///   - userFriendNo: 추가하는 유저 친구의 친구 목록 넘버 - `Body`
   case postUserFriend(userFriendNo: Int)
+  
+  /// 친구가 준 선물 전체 조회
+  /// - Parameters:
+  ///  - friendNo: 조회하는 친구의 DB 넘버 - `Path`
+  case getFriendGivenGifts(friendNo: Int)
+  
+  /// 친구가 받은 선물 전체 조회
+  /// - Parameters:
+  ///  - friendNo: 조회하는 친구의 DB 넘버 - `Path`
+  case getFriendReceivedGifts(friendNo: Int)
+
+  /// 친구의 선물 전체 조회
+  /// - Parameters:
+  ///  - friendNo: 조회하는 친구의 DB 넘버 - `Path`
+  case getFriendTotalGifts(friendNo: Int)
+
 }
 
 extension FriendAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Method.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Method.swift
@@ -26,6 +26,9 @@ extension GiftAPI {
       
     case .postGift:
       return .post
+      
+    case .patchPinGift:
+      return .patch
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Path.swift
@@ -26,6 +26,9 @@ extension GiftAPI {
       
     case .postGift:
       return "/gifts"
+      
+    case .patchPinGift(let giftNo):
+      return "/gifts/pin/\(giftNo)"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Path.swift
@@ -13,7 +13,7 @@ extension GiftAPI {
   public func getPath() -> String {
     switch self {
     case .getAllGifts:
-      return "/gifts"
+      return "/gifts/admin"
 
     case .getGift(let giftNo):
       return "/gifts/\(giftNo)"
@@ -24,8 +24,8 @@ extension GiftAPI {
     case .patchGift(_, let giftNo):
       return "/gifts/\(giftNo)"
       
-    case .postGift(_, let userNo):
-      return "/gifts/\(userNo)"
+    case .postGift:
+      return "/gifts"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Task.swift
@@ -27,6 +27,9 @@ extension GiftAPI {
       
     case .postGift(let giftRequestDTO):
       return .requestJSONEncodable(giftRequestDTO)
+      
+    case .patchPinGift:
+      return .requestPlain
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI+Task.swift
@@ -25,7 +25,7 @@ extension GiftAPI {
     case .patchGift(let giftRequestDTO, _):
       return .requestJSONEncodable(giftRequestDTO)
       
-    case .postGift(let giftRequestDTO, _):
+    case .postGift(let giftRequestDTO):
       return .requestJSONEncodable(giftRequestDTO)
     }
   }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI.swift
@@ -57,6 +57,11 @@ public enum GiftAPI {
   /// - Parameters:
   ///   - dto: 생성하는 선물의 정보를 담은 리퀘스트 DTO - `Body`
   case postGift(GiftRequestDTO)
+  
+  /// 선물 핀 여부 수정
+  /// - Parameters:
+  ///  - giftNo: 핀 여부를 수정하는 선물의 DB 넘버 - `Path`
+  case patchPinGift(giftNo: Int)
 }
 
 extension GiftAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Gift/GiftAPI.swift
@@ -22,7 +22,7 @@ public enum GiftAPI {
   /// - Parameters:
   ///   - giftNo: 삭제하는 선물의 DB 넘버 - `Path`
   case deleteGift(giftNo: Int)
-
+  
   /// 선물 수정
   /// ``` json
   /// // GiftUpdateRequestDTO
@@ -56,8 +56,7 @@ public enum GiftAPI {
   /// ```
   /// - Parameters:
   ///   - dto: 생성하는 선물의 정보를 담은 리퀘스트 DTO - `Body`
-  ///   - userNo: 선물을 생성하는 유저의 DB 넘버 - `Path`
-  case postGift(GiftRequestDTO, userNo: Int)
+  case postGift(GiftRequestDTO)
 }
 
 extension GiftAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Method.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Method.swift
@@ -24,6 +24,9 @@ extension ReminderAPI {
     case .patchReminder:
       return .patch
       
+    case .postFriendReminder:
+      return .post
+      
     case .postReminder:
       return .post
     }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Path.swift
@@ -13,7 +13,7 @@ extension ReminderAPI {
   public func getPath() -> String {
     switch self {
     case .getAllReminders:
-      return "/reminders"
+      return "/reminders/admin"
 
     case .getReminder(let reminderNo):
       return "/reminders/\(reminderNo)"
@@ -24,8 +24,11 @@ extension ReminderAPI {
     case .patchReminder(_, _, let reminderNo):
       return "/reminders/\(reminderNo)"
       
-    case .postReminder(_, let friendNo, let userNo):
-      return "/reminders/\(userNo)/\(friendNo)"
+    case .postFriendReminder(let anniversaryNo):
+      return "/reminders/\(anniversaryNo)"
+      
+    case .postReminder(_, let friendNo):
+      return "/reminders/\(friendNo)"
     }
   }
 }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI+Task.swift
@@ -30,7 +30,10 @@ extension ReminderAPI {
         ]
       )
       
-    case .postReminder(let reminderRequestDTO, _, _):
+    case .postFriendReminder:
+      return .requestPlain
+      
+    case .postReminder(let reminderRequestDTO, _):
       return .requestJSONEncodable(reminderRequestDTO)
     }
   }

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/Reminder/ReminderAPI.swift
@@ -17,7 +17,7 @@ public enum ReminderAPI {
   /// - Parameters:
   ///   - reminderNo: 조회하는 리마인더의 DB 넘버 - `Path`
   case getReminder(reminderNo: Int)
-
+  
   /// 리마인더 삭제
   /// - Parameters:
   ///   - reminderNo: 삭제하는 리마인더의 DB 넘버 - `Path`
@@ -39,6 +39,11 @@ public enum ReminderAPI {
   ///   - friendNo: 수정하는 리마인더와 관련된 친구의 DB 넘버 - `Query`
   ///   - reminderNo: 수정하는 리마인더의 DB 넘버 - `Path`
   case patchReminder(ReminderRequestDTO, friendNo: Int, reminderNo: Int)
+  
+  /// 친구의 기념을을 리마인더로 추가
+  /// - Parameters:
+  ///  - anniversaryNo: 친구의 기념일 넘버
+  case postFriendReminder(anniversaryNo: Int)
 
   /// 리마인더 생성
   /// ``` json
@@ -54,8 +59,7 @@ public enum ReminderAPI {
   /// - Parameters:
   ///   - dto: 리마인더 리퀘스트 DTO - `Body`
   ///   - friendNo: 리마인더와 관련된 친구의 DB 넘버 - `Path`
-  ///   - userNo: 리마인더를 생성하는 유저의 DB 넘버 - `Path`
-  case postReminder(ReminderRequestDTO, friendNo: Int, userNo: Int)
+  case postReminder(ReminderRequestDTO, friendNo: Int)
 }
 
 extension ReminderAPI: BaseTargetType {

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Method.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Method.swift
@@ -23,6 +23,9 @@ extension UserAPI {
 
     case .patchUser:
       return .patch
+      
+    case .getAllAnnivesaryList:
+      return .get
 
     case .getAllFriendList:
       return .get
@@ -35,6 +38,12 @@ extension UserAPI {
 
     case .getGiftByName:
       return .get
+      
+    case .getGiftsGivenByUser:
+      return .get
+      
+    case .getGiftsReceivedByUser:
+      return .get
 
     case .getAllGifts:
       return .get
@@ -46,6 +55,9 @@ extension UserAPI {
       return .patch
 
     case .getAllReminderList:
+      return .get
+      
+    case .getAllFilterReminderList:
       return .get
 
     case .postSignIn:

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Path.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Path.swift
@@ -13,40 +13,52 @@ extension UserAPI {
   public func getPath() -> String {
     switch self {
     case .getAllUsers:
+      return "/users/admin"
+
+    case .getUser:
+      return "/users"
+      
+    case .deleteUser:
       return "/users"
 
-    case .getUser(let userNo):
-      return "/users/\(userNo)"
+    case .patchUser:
+      return "/users"
+      
+    case .getAllAnnivesaryList:
+      return "/users/anniversaries"
 
-    case .deleteUser(let userNo):
-      return "/users/\(userNo)"
+    case .getAllFriendList:
+      return "/users/friends"
 
-    case .patchUser(_, _, _, let userNo):
-      return "/users/\(userNo)"
+    case .getGiftByCategory(let category):
+      return "/users/gifts-by-category/\(category)"
 
-    case .getAllFriendList(let userNo):
-      return "/users/friend-list/\(userNo)"
+    case .getGiftByEmotion(let emotion):
+      return "/users/gifts-by-emotion/\(emotion)"
 
-    case .getGiftByCategory(let category, let userNo):
-      return "/users/gift-by-category/\(userNo)/\(category)"
+    case .getGiftByName(let giftName):
+      return "/users/gifts-by-name/\(giftName)"
+      
+    case .getGiftsGivenByUser(let userNo):
+      return "/users/gifts-given\(userNo)"
+      
+    case .getGiftsReceivedByUser(let userNo):
+      return "/users/gifts-received/\(userNo)"
 
-    case .getGiftByEmotion(let emotion, let userNo):
-      return "/users/gift-by-emotion/\(userNo)/\(emotion)"
-
-    case .getGiftByName(let giftName, let userNo):
-      return "/users/gift-by-name/\(userNo)/\(giftName)"
-
-    case .getAllGifts(let userNo):
-      return "/users/gift-list/\(userNo)"
+    case .getAllGifts:
+      return "/users/gifts"
 
     case .getUserId(let userId):
-      return "/users/id/\(userId)"
+      return "/users/\(userId)"
 
-    case let .patchProfile(_, _, userNo):
-      return "/users/profile/\(userNo)"
+    case .patchProfile:
+      return "/users/profile"
 
-    case .getAllReminderList(let userNo):
-      return "/users/reminder-list/\(userNo)"
+    case .getAllReminderList:
+      return "/users/reminders"
+      
+    case let .getAllFilterReminderList(year, month):
+      return "/users/reminders/\(year)/\(month)"
 
     case .postSignIn:
       return "/users/sign-in"

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Task.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI+Task.swift
@@ -21,7 +21,7 @@ extension UserAPI {
     case .deleteUser:
       return .requestPlain
 
-    case .patchUser(let name, let userId, let favorList, _):
+    case .patchUser(let name, let userId, let favorList):
       return .requestParameters(
         parameters: [
           "name": name,
@@ -30,6 +30,9 @@ extension UserAPI {
         ],
         encoding: JSONEncoding.default
       )
+  
+    case .getAllAnnivesaryList:
+      return .requestPlain
 
     case .getAllFriendList:
       return .requestPlain
@@ -42,6 +45,12 @@ extension UserAPI {
 
     case .getGiftByName:
       return .requestPlain
+      
+    case .getGiftsGivenByUser:
+      return .requestPlain
+      
+    case .getGiftsReceivedByUser:
+      return .requestPlain
 
     case .getAllGifts:
       return .requestPlain
@@ -49,19 +58,19 @@ extension UserAPI {
     case .getUserId:
       return .requestPlain
 
-    case let .patchProfile(userId, name, userNo):
-      return .requestCompositeParameters(
-        bodyParameters: [
+    case let .patchProfile(userId, name):
+      return .requestParameters(
+        parameters: [
           "userId": userId,
           "name": name
         ],
-        bodyEncoding: JSONEncoding.default,
-        urlParameters: [
-          "userNo": userNo
-        ]
+        encoding: JSONEncoding.default
       )
 
     case .getAllReminderList:
+      return .requestPlain
+      
+    case .getAllFilterReminderList:
       return .requestPlain
 
     case let .postSignIn(email, password):

--- a/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI.swift
+++ b/Favor/FavorNetworkKit/Sources/FavorNetworkKit/APIs/User/UserAPI.swift
@@ -14,15 +14,11 @@ public enum UserAPI {
   case getAllUsers
 
   /// 단일 회원 조회
-  /// - Parameters:
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getUser(userNo: Int)
+  case getUser
 
   /// 회원 탈퇴
-  /// - Parameters:
-  ///   - userNo: 탈퇴하는 유저의 DB 넘버 - `Path`
-  case deleteUser(userNo: Int)
-
+  case deleteUser
+  
   /// 회원 수정
   /// ``` json
   /// // userUpdateRequestDTO
@@ -39,38 +35,43 @@ public enum UserAPI {
   ///   - name: 수정하는 유저의 이름 - `Body`
   ///   - userId: 수정하는 유저의 검색 아이디(@) - `Body`
   ///   - favorList: 수정하는 유저의 취향 목록 - `Body`
-  ///   - userNo: 수정하는 유저의 DB 넘버 - `Path`
-  case patchUser(name: String, userId: String, favorList: [String], userNo: Int)
-
+  case patchUser(name: String, userId: String, favorList: [String])
+  
+  /// 회원의 기념일 전체 조회
+  case getAllAnnivesaryList
+  
   /// 회원의 친구 전체 조회
-  /// - Parameters:
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getAllFriendList(userNo: Int)
+  case getAllFriendList
+  
+  /// 회원의 선물 전체 조회
+  case getAllGifts
 
   /// 카테고리로 회원 선물 조회
   /// - Parameters:
   ///   - category: 조회하는 선물의 카테고리 - `Path`
   ///     (*Available Values: 가벼운 선물, 생일, 집들이, 시험, 승진, 졸업, 기타*)
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getGiftByCategory(category: String, userNo: Int)
+  case getGiftByCategory(category: String)
 
   /// 감정으로 회원 선물 조회
   /// - Parameters:
   ///   - emotion: 조회하는 선물의 감정 - `Path`
   ///     (*Available Values: 감동이에요, 기뻐요, 좋아요, 그냥그래요, 별로에요*)
-  ///   - userNo:조회하는 유저의 DB 넘버 - `Path`
-  case getGiftByEmotion(emotion: String, userNo: Int)
+  case getGiftByEmotion(emotion: String)
 
   /// 이름으로 회원 선물 조회
   /// - Parameters:
   ///   - giftName: 조회하는 선물의 이름 - `Path`
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getGiftByName(giftName: String, userNo: Int)
-
-  /// 회원의 선물 전체 조회
+  case getGiftByName(giftName: String)
+  
+  /// 유저가 준 선물 전체 조회
   /// - Parameters:
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getAllGifts(userNo: Int)
+  ///  - userNo: 조회하는 유저의 DB 넘버 - `Path`
+  case getGiftsGivenByUser(userNo: Int)
+  
+  /// 유저가 받은 선물 전체 조회
+  /// - Parameters:
+  ///  - userNo: 조회하는 유저의 DB 넘버 - `Path`
+  case getGiftsReceivedByUser(userNo: Int)
 
   /// 아이디로 회원 조회
   /// - Parameters:
@@ -88,14 +89,18 @@ public enum UserAPI {
   /// - Parameters:
   ///   - userId: 생성하는 유저 프로필의 검색 아이디(@) - `Body`
   ///   - name: 생성하는 유저 프로필의 이름 - `Body`
-  ///   - userNo: 프로필을 생성하는 유저의 DB 넘버 - `Path`
-  case patchProfile(userId: String, name: String, userNo: Int)
+  case patchProfile(userId: String, name: String)
 
   /// 회원의 리마인더 전체 조회
+  case getAllReminderList
+  
+  /// 회원의 리마인더 필터 조회
   /// - Parameters:
-  ///   - userNo: 조회하는 유저의 DB 넘버 - `Path`
-  case getAllReminderList(userNo: Int)
-
+  ///  - year: 리마인더를 조회할 년도 값입니다.
+  ///  - month: 리마인더를 조회할 월 값입니다.
+  case getAllFilterReminderList(year: Int, month: Int)
+  
+  
   /// 로그인
   /// ``` json
   /// // signDTO


### PR DESCRIPTION
## ⚠️ 이슈 번호

> 브랜치에 할당된 이슈 번호
#173 

## ✌️ 구현/추가 사항

07.01 에 서버 재배포를 해가지고
업데이트된 API를 업데이트했어!

이젠 사용하지 않은 API도 있어서 일단 지우지는 않고 `Deprecated`처리를 해두었어.
그리고 Reactor에서 관련 API를 호출할 때 연관값을 대폭 수정했어!

## 💬 코멘트

> 추가한 기능에 대한 설명 및 리뷰 참고 사항
